### PR TITLE
feat: 멤버 관련 기능 및 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,16 @@ java {
 	sourceCompatibility = '11'
 }
 
+ext {
+	set('springCloudVersion', "2021.0.4")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
@@ -29,6 +39,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
@@ -38,6 +49,23 @@ dependencies {
 
 	//UUID
 	implementation 'com.github.f4b6a3:uuid-creator:5.3.2'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	//properties 프로세서
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
+	//OpenFeign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dnd/bbok/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/bbok/domain/member/controller/MemberController.java
@@ -1,0 +1,89 @@
+package com.dnd.bbok.domain.member.controller;
+
+import com.dnd.bbok.domain.member.dto.response.LoginResponseDto;
+import com.dnd.bbok.domain.member.dto.response.MemberInfoResponseDto;
+import com.dnd.bbok.domain.member.dto.response.MemberSimpleInfoResponse;
+import com.dnd.bbok.domain.member.service.MemberInfoService;
+import com.dnd.bbok.domain.member.service.MemberSignUpService;
+import com.dnd.bbok.global.jwt.SessionUser;
+import com.dnd.bbok.global.response.DataResponse;
+import com.dnd.bbok.infra.feign.dto.response.KakaoUserInfoResponseDto;
+import com.dnd.bbok.infra.feign.service.KakaoFeignService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@Api(tags = "멤버 관련 컨트롤러")
+public class MemberController {
+
+  private final KakaoFeignService kakaoFeignService;
+  private final MemberSignUpService memberSignUpService;
+  private final MemberInfoService memberInfoService;
+
+  /**
+   * 게스트 로그인 관련 컨트롤러
+   */
+  @ApiOperation(value = "게스트 회원가입")
+  @PostMapping("/api/v1/guest/signup")
+  public ResponseEntity<DataResponse<MemberSimpleInfoResponse>> guestLogin() {
+
+    LoginResponseDto guestLoginResponse = memberSignUpService.loginGuestMember();
+    HttpHeaders headers = memberSignUpService.setCookieAndHeader(guestLoginResponse);
+
+    return new ResponseEntity<>(DataResponse.of(HttpStatus.CREATED,
+        "게스트 회원 가입 성공", guestLoginResponse.getMember()), headers, HttpStatus.CREATED);
+  }
+
+  /**
+   * 유저가 자기 자신의 정보에 대해 알 수 있다.
+   */
+  @ApiOperation(value = "내 정보 조회")
+  @GetMapping("/api/v1/member")
+  public ResponseEntity<DataResponse<MemberInfoResponseDto>> getMember(
+      @AuthenticationPrincipal SessionUser sessionUser
+  ) {
+    MemberInfoResponseDto memberInfo = memberInfoService.getMember(sessionUser.getUuid());
+    return new ResponseEntity<>(
+        DataResponse.of(HttpStatus.OK, "멤버 정보 조회 성공", memberInfo), HttpStatus.OK);
+  }
+
+  /**
+   * 로그인 요청을 통해 인가코드를 redirect url로 발급 가능
+   */
+  @ApiOperation(value = "인가 코드 발급")
+  @GetMapping("/api/v1/login/kakao")
+  public ResponseEntity<HttpHeaders> getKakaoAuthCode()  {
+    HttpHeaders httpHeaders = kakaoFeignService.kakaoLogin();
+    return new ResponseEntity<>(httpHeaders, HttpStatus.SEE_OTHER);
+  }
+
+  /**
+   * 인가코드를 통해 accessToken 과 유저 정보를 가져온다.
+   */
+  @ApiOperation(value = "카카오 계정 회원가입")
+  @PostMapping("/api/v1/kakao/signup")
+  public ResponseEntity<DataResponse<MemberSimpleInfoResponse>> kakaoLogin(@RequestParam("code") String code) {
+
+    //코드를 통해 액세스 토큰 발급한 후, 유저 정보를 가져온다.
+    KakaoUserInfoResponseDto kakaoUserInfo = kakaoFeignService.getKakaoInfoWithToken(code);
+    LoginResponseDto kakaoLoginResponse = memberSignUpService.loginKakaoMember(kakaoUserInfo);
+    HttpHeaders headers = memberSignUpService.setCookieAndHeader(kakaoLoginResponse);
+
+    return new ResponseEntity<>(
+        DataResponse.of(
+            HttpStatus.CREATED, "카카오 계정으로 회원가입 성공", kakaoLoginResponse.getMember()), headers, HttpStatus.CREATED);
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/domain/member/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/dnd/bbok/domain/member/dto/response/LoginResponseDto.java
@@ -1,0 +1,24 @@
+package com.dnd.bbok.domain.member.dto.response;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+public class LoginResponseDto {
+
+  @ApiModelProperty("발급된 액세스 토큰")
+  private final String accessToken;
+
+  @ApiModelProperty("발급된 리프레쉬 토큰")
+  private final String refreshToken;
+
+  @ApiModelProperty("멤버의 id만 반환되는 dto")
+  private final MemberSimpleInfoResponse member;
+
+  public LoginResponseDto(String accessToken, String refreshToken, MemberSimpleInfoResponse member) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+    this.member = member;
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/domain/member/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/dnd/bbok/domain/member/dto/response/MemberInfoResponseDto.java
@@ -1,0 +1,31 @@
+package com.dnd.bbok.domain.member.dto.response;
+
+import com.dnd.bbok.domain.member.entity.Member;
+import com.dnd.bbok.domain.member.entity.OAuth2Provider;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+public class MemberInfoResponseDto {
+  @ApiModelProperty("member의 프로필 이미지 url")
+  private final String profileUrl;
+
+  @ApiModelProperty("member의 고유 Id")
+  private final String memberId;
+
+  @ApiModelProperty("member의 이름")
+  private final String memberName;
+
+  @ApiModelProperty("member의 oauth 제공자(GUEST, KAKAO)")
+  private final OAuth2Provider oauth2Provider;
+
+  public MemberInfoResponseDto(Member member) {
+    this.profileUrl = member.getProfileUrl();
+    this.memberId = member.getId().toString();
+    this.memberName =
+        member.getOauth2Provider().equals(OAuth2Provider.GUEST) ?
+        member.getUserNumber():member.getUsername();
+    this.oauth2Provider = member.getOauth2Provider();
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/domain/member/dto/response/MemberSimpleInfoResponse.java
+++ b/src/main/java/com/dnd/bbok/domain/member/dto/response/MemberSimpleInfoResponse.java
@@ -1,0 +1,17 @@
+package com.dnd.bbok.domain.member.dto.response;
+
+import com.dnd.bbok.domain.member.entity.Member;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+public class MemberSimpleInfoResponse {
+
+  @ApiModelProperty("member의 고유 Id")
+  private final String memberId;
+
+  public MemberSimpleInfoResponse(Member member) {
+    this.memberId = member.getId().toString();
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/domain/member/entity/Member.java
+++ b/src/main/java/com/dnd/bbok/domain/member/entity/Member.java
@@ -19,7 +19,7 @@ import org.hibernate.annotations.GenericGenerator;
 @Getter
 @NoArgsConstructor
 public class Member extends BaseTimeEntity {
-  
+
   @Id
   @GeneratedValue(generator = "uuid")
   @GenericGenerator(name = "uuid", strategy = "uuid2")

--- a/src/main/java/com/dnd/bbok/domain/member/entity/Member.java
+++ b/src/main/java/com/dnd/bbok/domain/member/entity/Member.java
@@ -5,16 +5,21 @@ import com.github.f4b6a3.uuid.UuidCreator;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.PrePersist;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Member extends BaseTimeEntity {
-
+  
   @Id
   @GeneratedValue(generator = "uuid")
   @GenericGenerator(name = "uuid", strategy = "uuid2")
@@ -22,13 +27,53 @@ public class Member extends BaseTimeEntity {
   private UUID id;
 
   /**
-   * id를 UUID로 저장했을 때의 단점(Long 보다 큰 용량을 차지)을 해결하기 위한 조치
-   * https://velog.io/@jsb100800/Spring-boot-JPA-PK-MAPPING
-   * https://cano721.tistory.com/214
+   * 역할(Guest, Social)
    */
+  @Enumerated(EnumType.STRING)
+  private Role role;
+
+  /**
+   * 회원번호 (oauthProvider#회원번호)
+   * 게스트 로그인한 사용자의 이름을 나타내기 위해서 생성했습니다.
+   */
+  private String userNumber;
+
+  /**
+   * SNS 로그인한 사용자의 이름
+   * 게스트 로그인 사용자의 이름은 NONE으로 설정했습니다.
+   */
+  private String username;
+
+  /**
+   * profile 이미지 url
+   */
+  private String profileUrl;
+
+  /**
+   * OAuth 제공자
+   */
+  @Enumerated(EnumType.STRING)
+  private OAuth2Provider oauth2Provider;
+
+
+
   @PrePersist
   public void createId() {
     this.id = UuidCreator.getTimeOrdered();
   }
 
+  @Builder
+  public Member(String profileUrl, String userNumber,
+      Role role, OAuth2Provider oauth2Provider, String username) {
+    this.userNumber = userNumber;
+    this.username = username;
+    this.profileUrl = profileUrl;
+    this.role = role;
+    this.oauth2Provider = oauth2Provider;
+  }
+
+  public void updateInfo(String profileUrl, String username) {
+    this.profileUrl = profileUrl;
+    this.username = username;
+  }
 }

--- a/src/main/java/com/dnd/bbok/domain/member/entity/OAuth2Provider.java
+++ b/src/main/java/com/dnd/bbok/domain/member/entity/OAuth2Provider.java
@@ -1,0 +1,10 @@
+package com.dnd.bbok.domain.member.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum OAuth2Provider {
+  KAKAO,
+  GUEST
+}
+

--- a/src/main/java/com/dnd/bbok/domain/member/entity/Role.java
+++ b/src/main/java/com/dnd/bbok/domain/member/entity/Role.java
@@ -1,0 +1,15 @@
+package com.dnd.bbok.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+  ROLE_GUEST("guest"),
+  ROLE_SOCIAL("social");
+
+  private final String authority;
+}
+

--- a/src/main/java/com/dnd/bbok/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/dnd/bbok/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,10 @@
+package com.dnd.bbok.domain.member.exception;
+
+import com.dnd.bbok.global.exception.BusinessException;
+import com.dnd.bbok.global.exception.ErrorCode;
+
+public class MemberNotFoundException extends BusinessException {
+  public MemberNotFoundException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/dnd/bbok/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/dnd/bbok/domain/member/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package com.dnd.bbok.domain.member.repository;
+
+import com.dnd.bbok.domain.member.entity.Member;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberRepository extends JpaRepository<Member, UUID> {
+
+  @Query("select m from Member m where m.id = :id")
+  Optional<Member> findById(@Param("id")UUID uuid);
+
+  @Query("select m from Member m where m.userNumber = :username")
+  Optional<Member> findByUsername(@Param("username") String username);
+}

--- a/src/main/java/com/dnd/bbok/domain/member/service/MemberInfoService.java
+++ b/src/main/java/com/dnd/bbok/domain/member/service/MemberInfoService.java
@@ -1,0 +1,23 @@
+package com.dnd.bbok.domain.member.service;
+
+import static com.dnd.bbok.global.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.dnd.bbok.domain.member.dto.response.MemberInfoResponseDto;
+import com.dnd.bbok.domain.member.entity.Member;
+import com.dnd.bbok.domain.member.exception.MemberNotFoundException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberInfoService {
+
+  private final MemberService memberService;
+
+  public MemberInfoResponseDto getMember(UUID memberId) {
+    Member member = memberService.getMemberById(memberId)
+        .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
+    return new MemberInfoResponseDto(member);
+  }
+}

--- a/src/main/java/com/dnd/bbok/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/bbok/domain/member/service/MemberService.java
@@ -28,7 +28,7 @@ public class MemberService {
         )
         .username("NONE")
         .role(Role.ROLE_GUEST)
-        .profileUrl("기본 이미지 url")
+        .profileUrl("https://i.ibb.co/JQbdnX6/guest.png")
         .oauth2Provider(OAuth2Provider.GUEST)
         .build();
   }

--- a/src/main/java/com/dnd/bbok/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/bbok/domain/member/service/MemberService.java
@@ -28,7 +28,7 @@ public class MemberService {
         )
         .username("NONE")
         .role(Role.ROLE_GUEST)
-        .profileUrl("https://i.ibb.co/JQbdnX6/guest.png")
+        .profileUrl("https://i.ibb.co/34SNTwm/image.png")
         .oauth2Provider(OAuth2Provider.GUEST)
         .build();
   }

--- a/src/main/java/com/dnd/bbok/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/bbok/domain/member/service/MemberService.java
@@ -1,0 +1,48 @@
+package com.dnd.bbok.domain.member.service;
+
+import com.dnd.bbok.domain.member.entity.Member;
+import com.dnd.bbok.domain.member.entity.OAuth2Provider;
+import com.dnd.bbok.domain.member.entity.Role;
+import com.dnd.bbok.domain.member.repository.MemberRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+  private final MemberRepository memberRepository;
+
+  public Member saveGuestMember() {
+    Member guest = createGuestMember();
+    return memberRepository.save(guest);
+  }
+
+  private Member createGuestMember() {
+    return Member.builder()
+        .userNumber(
+            String.format("%s#%s", OAuth2Provider.GUEST, UUID.randomUUID().toString().split("-")[0])
+        )
+        .username("NONE")
+        .role(Role.ROLE_GUEST)
+        .profileUrl("기본 이미지 url")
+        .oauth2Provider(OAuth2Provider.GUEST)
+        .build();
+  }
+
+  public Optional<Member> getMemberByUserNumber(String username) {
+    return memberRepository.findByUsername(username);
+  }
+
+  public Member saveInfo(Member member) {
+    return memberRepository.save(member);
+  }
+
+  public Optional<Member> getMemberById(UUID uuid) {
+    log.info("해당 uuid를 가진 멤버를 찾습니다.");
+    return memberRepository.findById(uuid);
+  }
+}

--- a/src/main/java/com/dnd/bbok/domain/member/service/MemberSignUpService.java
+++ b/src/main/java/com/dnd/bbok/domain/member/service/MemberSignUpService.java
@@ -1,0 +1,69 @@
+package com.dnd.bbok.domain.member.service;
+
+import com.dnd.bbok.domain.member.dto.response.MemberSimpleInfoResponse;
+import com.dnd.bbok.global.util.CookieUtil;
+import com.dnd.bbok.global.util.HttpHeaderUtil;
+import com.dnd.bbok.infra.feign.dto.response.KakaoUserInfoResponseDto;
+import com.dnd.bbok.global.jwt.JwtTokenProvider;
+import com.dnd.bbok.domain.member.dto.response.LoginResponseDto;
+import com.dnd.bbok.domain.member.entity.Member;
+import com.dnd.bbok.domain.member.entity.OAuth2Provider;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberSignUpService {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final MemberService memberService;
+
+  public LoginResponseDto loginGuestMember() {
+    Member guest = memberService.saveGuestMember();
+    return createSignUpResult(guest);
+  }
+
+  public LoginResponseDto loginKakaoMember(KakaoUserInfoResponseDto kakaoUserInfo) {
+    //카카오 회원 Id를 변조해서 검사해본다.(회원 Id로 해야만 고유성을 가질 수 있기 때문에)
+    String userNumber = String.format("%s#%s", OAuth2Provider.KAKAO, kakaoUserInfo.getId());
+    Optional<Member> loginMember = memberService.getMemberByUserNumber(userNumber);
+
+    //만약 존재한다면, update 친다.
+    if(loginMember.isPresent()) {
+      Member member = loginMember.get();
+      updateMemberInfo(kakaoUserInfo, member);
+      //토큰 새로 생성이 아닌, 이후에 refreshToken 체크해서 accessToken을 다시 발급해주는 로직을 넣어야 함.
+      return createSignUpResult(member);
+    }
+
+    //2-2. 존재하지 않는다면, user를 생성해서 넣어준다.
+    Member member = signUp(kakaoUserInfo);
+    return createSignUpResult(member);
+  }
+
+  private LoginResponseDto createSignUpResult(Member member) {
+    String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getRole());
+    String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+    return new LoginResponseDto(accessToken, refreshToken, new MemberSimpleInfoResponse(member));
+  }
+
+  private Member signUp(KakaoUserInfoResponseDto kakaoUserInfo) {
+    Member member = kakaoUserInfo.toEntity();
+    return memberService.saveInfo(member);
+  }
+
+  private void updateMemberInfo(KakaoUserInfoResponseDto kakaoUserInfo, Member member) {
+    member.updateInfo(kakaoUserInfo.getProfileImg(), kakaoUserInfo.getUsername());
+  }
+
+  public HttpHeaders setCookieAndHeader(LoginResponseDto loginResult) {
+    HttpHeaders headers = new HttpHeaders();
+    CookieUtil.setRefreshCookie(headers, loginResult.getRefreshToken());
+    HttpHeaderUtil.setAccessToken(headers, loginResult.getAccessToken());
+    return headers;
+  }
+}

--- a/src/main/java/com/dnd/bbok/domain/member/service/MemberSignUpService.java
+++ b/src/main/java/com/dnd/bbok/domain/member/service/MemberSignUpService.java
@@ -40,7 +40,7 @@ public class MemberSignUpService {
       return createSignUpResult(member);
     }
 
-    //2-2. 존재하지 않는다면, user를 생성해서 넣어준다.
+    //존재하지 않는다면, user를 생성해서 넣어준다.
     Member member = signUp(kakaoUserInfo);
     return createSignUpResult(member);
   }

--- a/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
@@ -14,9 +14,12 @@ public enum ErrorCode {
   METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "지원하지 않는 Http Method 입니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 에러"),
   INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "입력 값의 타입이 올바르지 않습니다."),
-  HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C005", "접근이 거부 되었습니다.");
+  HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C005", "접근이 거부 되었습니다."),
+  RESOURCE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "R002", "인증이 필요합니다. 로그인을 해주세요."),
+  RESOURCE_FORBIDDEN(HttpStatus.FORBIDDEN, "R001", "해당 리소스에 대한 권한이 없습니다."),
 
-  // Domain 별로 코드 정의해서 추가하면 됩니다.
+  // Member
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 uuid를 가진 멤버를 찾을 수 없습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/dnd/bbok/global/jwt/JwtAuthenticationEntryPointHandler.java
+++ b/src/main/java/com/dnd/bbok/global/jwt/JwtAuthenticationEntryPointHandler.java
@@ -1,0 +1,25 @@
+package com.dnd.bbok.global.jwt;
+
+import static com.dnd.bbok.global.exception.ErrorCode.RESOURCE_UNAUTHORIZED;
+
+import com.dnd.bbok.global.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType("application/json;charset=UTF-8");
+    objectMapper.writeValue(response.getWriter(), ErrorResponse.of(RESOURCE_UNAUTHORIZED));
+  }
+}

--- a/src/main/java/com/dnd/bbok/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/bbok/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package com.dnd.bbok.global.jwt;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  /**
+   * 1. request header 에서 Authorization 값을 가져온다.
+   *
+   * 1-1. Authorization 값이 없다면? 사용자가 처음 요청
+   * accessToken 발급 / 해당 유저를 저장한 후에 UUID를 발급하여 응답한다.
+   *
+   * 1-2. Authorization 값이 있다면? 유효성 검증
+   * 토큰이 올바른지와 만료됐는지 검증한다.
+   * 유효성 검증에서 실패하면 정의한 예외 처리를 해준다.
+   */
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    //사용자의 요청 헤더에서 Authorization 값을 가져온다.
+    String header = request.getHeader(AUTHORIZATION);
+
+    if(validateHeader(header)) {
+      // 헤더에서 JWT를 받아온다.
+      String accessToken = header.substring(7);
+
+      log.info("accessToken: {} 으로 Authentication 객체를 찾습니다.", accessToken);
+      Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+
+      //SecurityContext에 Authentication 객체를 저장한다.
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+      log.info("SecurityContextHolder 에 Authentication 객체를 저장했습니다. 인증 완료 {}",
+          authentication.getName());
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * header가 null이거나, Bearer로 시작하는지 검증한다.
+   */
+  private boolean validateHeader(String header) {
+    return header != null && header.startsWith("Bearer ");
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/global/jwt/JwtException.java
+++ b/src/main/java/com/dnd/bbok/global/jwt/JwtException.java
@@ -1,0 +1,18 @@
+package com.dnd.bbok.global.jwt;
+
+import com.dnd.bbok.global.exception.ErrorCode;
+
+public class JwtException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public JwtException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/global/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/dnd/bbok/global/jwt/JwtExceptionFilter.java
@@ -1,0 +1,30 @@
+package com.dnd.bbok.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.dnd.bbok.global.exception.ErrorResponse;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      filterChain.doFilter(request, response);
+    } catch (JwtException e) {
+      response.setStatus(e.getErrorCode().getStatus());
+      response.setContentType("application/json");
+      response.setCharacterEncoding("UTF-8");
+      objectMapper.writeValue(response.getWriter(), ErrorResponse.of(e.getErrorCode()));
+    }
+  }
+}

--- a/src/main/java/com/dnd/bbok/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dnd/bbok/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,148 @@
+package com.dnd.bbok.global.jwt;
+
+import com.dnd.bbok.domain.member.entity.Member;
+import com.dnd.bbok.domain.member.entity.Role;
+import com.dnd.bbok.domain.member.repository.MemberRepository;
+import com.dnd.bbok.infra.redis.RefreshToken;
+import com.dnd.bbok.infra.redis.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.security.Key;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+/**
+ * 토큰 발급해주는 서비스(Jwt 도메인의 Service 라고 생각하는 것이 좋다)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+  private final MemberRepository memberRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  //  jwt를 생성해주는 secretKey
+  private static String secretKey = "MFswDQYJKoZIhvcNAQEBBQADSgAwRwJAaJd167MUifo3ZSytpDPd9z7oSS+1KXjf\n"
+      + "HJ3oMvI61Id26fdQHgWE1QMLcrhOmRzTxkCU+gesx5ANkSSIrPHNswIDAQAB";
+
+  //accessToken 만료시간
+  public static final Long ACCESS_TOKEN_EXPIRE_LENGTH_MS = 1000L * 60 * 60; // 1hour
+
+  //refreshToken 만료시간
+  public static final Long REFRESH_TOKEN_EXPIRE_LENGTH_MS = 1000L * 60 * 60 * 24 * 14; //2주
+
+  private Key key;
+
+  @PostConstruct
+  protected void init() {
+    secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+    key = Keys.hmacShaKeyFor(keyBytes);
+  }
+
+  //accessToken을 사용하여 Authentication 객체를 생성한다.
+  public Authentication getAuthentication(String accessToken) {
+    Claims claims = extractAllClaims(accessToken); //claims 정보를 추출할때 유효성 체크를 시작한다.
+    String role = claims.get("role").toString();
+    String uuid = claims.getSubject();
+    return new UsernamePasswordAuthenticationToken(getSessionUser(uuid), "",
+        getGrantedAuthorities(role));
+  }
+
+  private SessionUser getSessionUser(String uuid) {
+    UUID changeUuid = UUID.fromString(uuid);
+    log.info("session user 를 만들기 위해서 uuid : {} 인 사람을 찾습니다.", uuid);
+    Optional<Member> optionalMember = memberRepository.findById(changeUuid);
+
+    if (optionalMember.isEmpty()) {
+      throw new JwtException("유효하지 않은 토큰");
+    }
+    return new SessionUser(optionalMember.get());
+  }
+
+  private static List<GrantedAuthority> getGrantedAuthorities(String role) {
+    List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+    grantedAuthorities.add(new SimpleGrantedAuthority(role));
+    return grantedAuthorities;
+  }
+
+  /**
+   * 게스트로 진입할때, 해당 유저를 DB에 저장하고 난 후의 UUID로 accessToken을 생성한다.
+   * 유효시간은 1시간으로 설정해놓았다.
+   */
+  public String createAccessToken(UUID uuid, Role role) {
+    Date now = new Date();
+    Date validity = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_LENGTH_MS);
+
+    return Jwts.builder()
+        .signWith(key, SignatureAlgorithm.HS256)
+        .setSubject(uuid.toString())
+        .claim("role", role.getAuthority())
+        .setIssuer("bbok")
+        .setIssuedAt(now)
+        .setExpiration(validity)
+        .compact();
+  }
+
+  /**
+   * Refresh Token 을 생성한다.
+   * 유효 시간은 14일로 설정한다.
+   * @return 생성된 Refresh Token
+   */
+  public String createRefreshToken(UUID memberId) {
+    Date now = new Date();
+    Date validity = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_LENGTH_MS);
+
+    String refreshToken = Jwts.builder()
+        .signWith(key, SignatureAlgorithm.HS256)
+        .setIssuer("bbok")
+        .setIssuedAt(now)
+        .setExpiration(validity)
+        .compact();
+
+    RefreshToken token = new RefreshToken(memberId, refreshToken);
+    refreshTokenRepository.save(token);
+    return refreshToken;
+  }
+
+  private Claims extractAllClaims(String token) {
+    return checkClaims(token).getBody();
+  }
+
+  private Jws<Claims> checkClaims(String token) {
+    try {
+      return Jwts.parserBuilder().setSigningKey(secretKey).build()
+          .parseClaimsJws(token);
+    } catch (MalformedJwtException | SignatureException | UnsupportedJwtException e) {
+      log.warn("유효하지 않은 토큰입니다.", e);
+      throw new JwtException("JWT_INVALID_TOKEN");
+    } catch (ExpiredJwtException e) {
+      log.warn("만료된 토큰입니다.", e);
+      throw new JwtException("JWT_EXPIRED_TOKEN");
+    }
+  }
+
+
+
+}

--- a/src/main/java/com/dnd/bbok/global/jwt/SessionUser.java
+++ b/src/main/java/com/dnd/bbok/global/jwt/SessionUser.java
@@ -1,0 +1,21 @@
+package com.dnd.bbok.global.jwt;
+
+import com.dnd.bbok.domain.member.entity.Member;
+import java.io.Serializable;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SessionUser implements Serializable {
+
+  private final UUID uuid;
+  private final String authority;
+
+  public SessionUser(Member member) {
+    this.uuid = member.getId();
+    this.authority = member.getRole().getAuthority();
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/dnd/bbok/global/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,26 @@
+package com.dnd.bbok.global.security;
+
+import static com.dnd.bbok.global.exception.ErrorCode.RESOURCE_FORBIDDEN;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.dnd.bbok.global.exception.ErrorResponse;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException)
+      throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    response.setContentType("application/json;charset=UTF-8");
+    objectMapper.writeValue(response.getWriter(), ErrorResponse.of(RESOURCE_FORBIDDEN));
+  }
+}

--- a/src/main/java/com/dnd/bbok/global/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/bbok/global/security/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.dnd.bbok.global.security;
+
+import com.dnd.bbok.global.jwt.JwtAuthenticationFilter;
+import com.dnd.bbok.global.jwt.JwtExceptionFilter;
+import com.dnd.bbok.global.jwt.JwtAuthenticationEntryPointHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final JwtExceptionFilter jwtExceptionFilter;
+  private final JwtAuthenticationEntryPointHandler jwtAuthenticationEntryPointHandler;
+  private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.cors() //cors 설정 활성화
+        .and()
+        .csrf().disable() //CSRF 보호 기능 비활성화
+        .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+    http//HTTP 헤더에 사용자의 이름과 암호 포함을 비활성화
+        .authorizeRequests()
+        .antMatchers(HttpMethod.GET, "/test", "/api/v1/member").authenticated() //해당 요청은 인증이 필요하다.
+        .antMatchers("/**").permitAll() //해당 요청은 누구나 다 들어올 수 있다.
+        .and()
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
+
+    http.exceptionHandling()
+        .authenticationEntryPoint(jwtAuthenticationEntryPointHandler) // 인증 되지 않는 사용자가 접근할 경우
+        .accessDeniedHandler(jwtAccessDeniedHandler); // 인증은 했으나 권한이 없는 경우
+
+    return http.build();
+  }
+
+
+}

--- a/src/main/java/com/dnd/bbok/global/util/CookieUtil.java
+++ b/src/main/java/com/dnd/bbok/global/util/CookieUtil.java
@@ -1,0 +1,42 @@
+package com.dnd.bbok.global.util;
+
+import static com.dnd.bbok.global.jwt.JwtTokenProvider.REFRESH_TOKEN_EXPIRE_LENGTH_MS;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+
+/**
+ * Cookie 관련 유틸리티 클래스.
+ */
+public class CookieUtil {
+
+  private CookieUtil() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  public static void setRefreshCookie(HttpHeaders httpHeaders, String refreshToken) {
+
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .httpOnly(true)
+        .secure(true)
+        .maxAge(REFRESH_TOKEN_EXPIRE_LENGTH_MS)
+        .path("/")
+        .sameSite("None")
+        .build();
+
+    httpHeaders.add(HttpHeaders.SET_COOKIE, cookie.toString());
+  }
+
+  public static void resetRefreshToken(HttpHeaders headers) {
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+        .httpOnly(true)
+        .secure(true)
+        .maxAge(0)
+        .path("/")
+        .sameSite("None")
+        .build();
+
+    headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
+  }
+}

--- a/src/main/java/com/dnd/bbok/global/util/HttpHeaderUtil.java
+++ b/src/main/java/com/dnd/bbok/global/util/HttpHeaderUtil.java
@@ -1,0 +1,19 @@
+package com.dnd.bbok.global.util;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import org.springframework.http.HttpHeaders;
+
+/**
+ * access Token 을 Header 의 Authorization 에 담는다.
+ */
+public class HttpHeaderUtil {
+
+  private HttpHeaderUtil() {
+  }
+
+  public static void setAccessToken(HttpHeaders headers, String accessToken) {
+    // set access token header
+    headers.set(AUTHORIZATION, "Bearer " + accessToken);
+  }
+}

--- a/src/main/java/com/dnd/bbok/infra/feign/client/KakaoInfoClient.java
+++ b/src/main/java/com/dnd/bbok/infra/feign/client/KakaoInfoClient.java
@@ -1,0 +1,21 @@
+package com.dnd.bbok.infra.feign.client;
+
+import com.dnd.bbok.infra.feign.config.KakaoFeignConfig;
+import com.dnd.bbok.infra.feign.dto.response.KakaoUserInfoResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+/**
+ * 카카오 사용자 정보 얻어오는 feign client
+ */
+@FeignClient(name = "kakaoInfoClient", url = "https://kapi.kakao.com", configuration = KakaoFeignConfig.class)
+@Component
+public interface KakaoInfoClient {
+
+  //https://kapi.kakao.com/v2/user/me => 회원 정보 요청 url
+  @GetMapping(value = "/v2/user/me")
+  KakaoUserInfoResponseDto getUserInfo(@RequestHeader(name = "Authorization") String Authorization);
+
+}

--- a/src/main/java/com/dnd/bbok/infra/feign/client/KakaoTokenClient.java
+++ b/src/main/java/com/dnd/bbok/infra/feign/client/KakaoTokenClient.java
@@ -1,0 +1,21 @@
+package com.dnd.bbok.infra.feign.client;
+
+import com.dnd.bbok.infra.feign.config.KakaoFeignConfig;
+import com.dnd.bbok.infra.feign.dto.response.KakaoTokenResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * 카카오 토큰 관련 feign client
+ */
+@FeignClient(name = "kakaoTokenClient", url = "https://kauth.kakao.com", configuration = KakaoFeignConfig.class)
+@Component
+public interface KakaoTokenClient {
+
+  //https://kauth.kakao.com/oauth/token => 카카오 토큰 받기 url
+  @PostMapping(value = "/oauth/token")
+  KakaoTokenResponseDto getToken(@RequestBody String kakaoTokenRequestDto);
+
+}

--- a/src/main/java/com/dnd/bbok/infra/feign/config/KakaoFeignConfig.java
+++ b/src/main/java/com/dnd/bbok/infra/feign/config/KakaoFeignConfig.java
@@ -1,0 +1,28 @@
+package com.dnd.bbok.infra.feign.config;
+
+import feign.Logger;
+import feign.RequestInterceptor;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.dnd.bbok.infra")
+public class KakaoFeignConfig {
+
+  @Bean
+  Logger.Level feignLoggerLevel() {
+    return Logger.Level.FULL;
+  }
+
+  @Bean
+  public RequestInterceptor requestInterceptor() {
+    return template -> template.header("Content-Type", "application/x-www-form-urlencoded");
+  }
+
+//  @Bean
+//  public ErrorDecoder errorDecoder() {
+//    return new FeignClientExceptionErrorDecoder();
+//  }
+
+}

--- a/src/main/java/com/dnd/bbok/infra/feign/dto/KakaoInfo.java
+++ b/src/main/java/com/dnd/bbok/infra/feign/dto/KakaoInfo.java
@@ -1,0 +1,43 @@
+package com.dnd.bbok.infra.feign.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * yml 정보를 잇는 클래스
+ */
+@Slf4j
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "oauth2.kakao")
+public class KakaoInfo {
+
+  private String baseUrl;
+  private String clientId;
+  private String redirectUri;
+  private String secretKey;
+
+  public String kakaoUrlInit() {
+    Map<String, Object> params = new HashMap<>();
+    params.put("redirect_uri", getRedirectUri());
+    params.put("client_id", getClientId());
+    params.put("response_type", "code");
+
+    String paramStr = params.entrySet().stream()
+        .map(param -> param.getKey() + "=" + param.getValue())
+        .collect(Collectors.joining("&"));
+
+    return getBaseUrl()
+        +"/oauth/authorize"
+        + "?"
+        + paramStr;
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/infra/feign/dto/request/KakaoTokenRequestDto.java
+++ b/src/main/java/com/dnd/bbok/infra/feign/dto/request/KakaoTokenRequestDto.java
@@ -1,0 +1,44 @@
+package com.dnd.bbok.infra.feign.dto.request;
+
+import com.dnd.bbok.infra.feign.dto.KakaoInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 카카오 액세스 토큰을 얻기 위한 request Dto
+ * 액세스 토큰을 얻어야만 사용자 정보를 가져올 수 있다.
+ */
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class KakaoTokenRequestDto {
+
+  private String code;
+  private String client_id;
+  private String client_secret;
+  private String redirect_uri;
+  private final String grant_type = "authorization_code";
+
+  public static KakaoTokenRequestDto newInstance(KakaoInfo kakaoInfo, String code) {
+    return KakaoTokenRequestDto.builder()
+        .client_id(kakaoInfo.getClientId())
+        .client_secret(kakaoInfo.getSecretKey())
+        .redirect_uri(kakaoInfo.getRedirectUri())
+        .code(code)
+        .build();
+  }
+
+  @Override
+  public String toString() {
+    return
+        "code=" + code + '&' +
+            "client_id=" + client_id + '&' +
+            "client_secret=" + client_secret + '&' +
+            "redirect_uri=" + redirect_uri + '&' +
+            "grant_type=" + grant_type;
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/infra/feign/dto/response/KakaoTokenResponseDto.java
+++ b/src/main/java/com/dnd/bbok/infra/feign/dto/response/KakaoTokenResponseDto.java
@@ -1,0 +1,45 @@
+package com.dnd.bbok.infra.feign.dto.response;
+
+import lombok.Getter;
+
+/**
+ * 카카오 액세스 토큰 정보 응답 Dto
+ */
+@Getter
+public class KakaoTokenResponseDto {
+
+  /**
+   * 반환되는 토큰 타입(Bearer 고정)
+   */
+  private String token_type;
+
+  /**
+   * 사용자의 accessToken 값
+   */
+  private String access_token;
+
+  /**
+   * accessToken 만료 시간
+   */
+  private String expires_in;
+
+  /**
+   * 사용자의 refreshToken 값
+   */
+  private String refresh_token;
+
+  /**
+   * refreshToken 만료 시간
+   */
+  private String refresh_token_expires_in;
+
+  public String getAccessToken() {
+    return "Bearer " + access_token;
+  }
+
+  @Override
+  public String toString() {
+    return "액세스 토큰입니다: " + access_token;
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/infra/feign/dto/response/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/dnd/bbok/infra/feign/dto/response/KakaoUserInfoResponseDto.java
@@ -1,0 +1,66 @@
+package com.dnd.bbok.infra.feign.dto.response;
+
+import com.dnd.bbok.domain.member.entity.Member;
+import com.dnd.bbok.domain.member.entity.OAuth2Provider;
+import com.dnd.bbok.domain.member.entity.Role;
+import lombok.Getter;
+
+/**
+ * 카카오 서버에서 어떤 정보를 가져올지
+ */
+@Getter
+public class KakaoUserInfoResponseDto {
+
+  /**
+   * 회원 번호
+   */
+  private Long id;
+
+  /**
+   * 카카오 계정 정보
+   */
+  private KakaoAccount kakao_account;
+
+  @Getter
+  static class KakaoAccount {
+    private Profile profile;
+  }
+
+  @Getter
+  static class Profile {
+    private String nickname;
+    private String profile_image_url;
+  }
+
+  @Override
+  public String toString() {
+    return
+        "id = " + this.id +
+        "profile.nickname = " + this.kakao_account.profile.nickname +
+            "profile.profile_img_url = " + this.kakao_account.profile.profile_image_url;
+  }
+
+  public String getProfileImg() {
+    return this.getKakao_account().getProfile().profile_image_url;
+  }
+
+  public String getUsername() {
+    return this.getKakao_account().getProfile().getNickname();
+  }
+
+  public String createUserNumber() {
+    return String.format("%s#%s", OAuth2Provider.KAKAO, this.getId());
+  }
+
+  public Member toEntity() {
+    return Member.builder()
+        .username(this.getUsername())
+        .userNumber(createUserNumber())
+        .role(Role.ROLE_SOCIAL)
+        .oauth2Provider(OAuth2Provider.KAKAO)
+        .profileUrl(this.getProfileImg())
+        .build();
+  }
+
+
+}

--- a/src/main/java/com/dnd/bbok/infra/feign/service/KakaoFeignService.java
+++ b/src/main/java/com/dnd/bbok/infra/feign/service/KakaoFeignService.java
@@ -65,7 +65,6 @@ public class KakaoFeignService {
   private String getKakaoToken(String code) {
     KakaoTokenResponseDto token = kakaoTokenClient.getToken(
         KakaoTokenRequestDto.newInstance(kakaoInfo, code).toString());
-//    log.info(token.toString());
     return token.getAccessToken();
   }
 

--- a/src/main/java/com/dnd/bbok/infra/feign/service/KakaoFeignService.java
+++ b/src/main/java/com/dnd/bbok/infra/feign/service/KakaoFeignService.java
@@ -1,0 +1,73 @@
+package com.dnd.bbok.infra.feign.service;
+
+import com.dnd.bbok.infra.feign.client.KakaoInfoClient;
+import com.dnd.bbok.infra.feign.client.KakaoTokenClient;
+import com.dnd.bbok.infra.feign.dto.KakaoInfo;
+import com.dnd.bbok.infra.feign.dto.request.KakaoTokenRequestDto;
+import com.dnd.bbok.infra.feign.dto.response.KakaoTokenResponseDto;
+import com.dnd.bbok.infra.feign.dto.response.KakaoUserInfoResponseDto;
+import java.net.URI;
+import java.net.URISyntaxException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoFeignService {
+
+  private final KakaoTokenClient kakaoTokenClient;
+  private final KakaoInfoClient kakaoInfoClient;
+  private final KakaoInfo kakaoInfo;
+
+  public HttpHeaders kakaoLogin(){
+    return createHttpHeader(kakaoInfo.kakaoUrlInit());
+  }
+
+  private static HttpHeaders createHttpHeader(String requestUrl) {
+    try {
+      URI uri = new URI(requestUrl);
+      HttpHeaders httpHeaders = new HttpHeaders();
+      httpHeaders.setLocation(uri);
+      return httpHeaders;
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  /**
+   * 인가 코드를 가지고 토큰을 가져옵니다.
+   * @param code 카카오 서버에서 내려준 인가 코드
+   * @return 해당 사용자 정보 response dto
+   */
+  public KakaoUserInfoResponseDto getKakaoInfoWithToken(String code) {
+    //1. 인가 코드를 가지고 토큰을 가져온다.
+    String kakaoToken = getKakaoToken(code);
+    //2. 해당 토큰으로 user 정보를 들고온다.
+    return getKakaoInfo(kakaoToken);
+  }
+
+  /**
+   * 카카오 액세스 토큰으로 유저 정보를 요청합니다.
+   */
+  private KakaoUserInfoResponseDto getKakaoInfo(String kakaoToken) {
+    return kakaoInfoClient.getUserInfo(kakaoToken);
+  }
+
+  /**
+   * 인가 코드를 가지고 토큰을 가져옵니다.
+   * @param code 서버에서 내려주는 인가코드.
+   * @return accessToken
+   */
+  private String getKakaoToken(String code) {
+    KakaoTokenResponseDto token = kakaoTokenClient.getToken(
+        KakaoTokenRequestDto.newInstance(kakaoInfo, code).toString());
+//    log.info(token.toString());
+    return token.getAccessToken();
+  }
+
+
+}

--- a/src/main/java/com/dnd/bbok/infra/redis/RefreshToken.java
+++ b/src/main/java/com/dnd/bbok/infra/redis/RefreshToken.java
@@ -1,0 +1,19 @@
+package com.dnd.bbok.infra.redis;
+
+import java.util.UUID;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash(value = "memberId", timeToLive = 1000L * 60 * 60 * 24 * 14)
+public class RefreshToken {
+
+  @Id
+  private UUID memberId;
+  private String refreshToken;
+
+  public RefreshToken(UUID memberId, String refreshToken) {
+    this.memberId = memberId;
+    this.refreshToken = refreshToken;
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/infra/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/dnd/bbok/infra/redis/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.dnd.bbok.infra.redis;
+
+import java.util.UUID;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.repository.CrudRepository;
+
+@EnableRedisRepositories
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, UUID> {
+
+
+
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,4 +25,4 @@ oauth2:
     baseUrl: https://kauth.kakao.com
     clientId: 3fca0db05482af0333a5fb5b9dc5b345
     redirectUri: http://localhost:8080/api/v1/account/kakao/result
-    secretKey: I3kIzkCakoD21D5jiFVSyFQJoBbAbgU5
+    secretKey: ${SECRET_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,3 +18,11 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+
+oauth2:
+  kakao:
+    infoUrl: https://kapi.kakao.com
+    baseUrl: https://kauth.kakao.com
+    clientId: 3fca0db05482af0333a5fb5b9dc5b345
+    redirectUri: http://localhost:8080/api/v1/account/kakao/result
+    secretKey: I3kIzkCakoD21D5jiFVSyFQJoBbAbgU5

--- a/src/main/resources/redis-server.yml
+++ b/src/main/resources/redis-server.yml
@@ -1,0 +1,13 @@
+# redis-server.yml
+version: '7.0.12'
+services:
+  redis:
+    image: redis:alpine
+    command: redis-server --port 6379
+    container_name: redis_docker
+    hostname: redis_docker
+    labels:
+      - "name=redis"
+      - "mode=standalone"
+    ports:
+      - 6379:6379


### PR DESCRIPTION
## What is this PR? 🔍
- Spring security, jwt를 도입하여 게스트 로그인과 카카오 로그인 기능을 구현했습니다.

## Key Changes 📝
- [X] Member 엔티티 필드 추가
- [X] refresh token 관리를 위해 redis 서버를 도커로 띄우는 redis-server.yml 파일 추가
- [X] 로그인 기능 구현

## Test Checklist ✅
- [ ] Nothing

## To Reviewers
기능을 바로 구현해서 Mock 이 아닌 실제 컨트롤러 클래스에 작업했습니다!
`docker-compose -f ./redis-server.yml up -d` 로 로컬에서 레디스를 띄울 수 있습니다!
토큰 validation 체크나 재발행 서비스 로직은 곧바로 작업할 예정입니다.
변수명 고민이 힘들어... 리뷰하시면서 클래스명 괜찮은지 체크 부탁드립니다!