### PR TITLE
setting: SwaggerConfig 변경

### DIFF
--- a/src/main/java/com/dnd/bbok/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/bbok/domain/member/controller/MemberController.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,7 +36,9 @@ public class MemberController {
   /**
    * 게스트 로그인 관련 컨트롤러
    */
-  @ApiOperation(value = "게스트 회원가입")
+  @ApiOperation(
+      value = "게스트 회원가입",
+      notes = "요청 보내면 바로 게스트가 생성되고, accessToken이 발급됩니다.")
   @PostMapping("/api/v1/guest/signup")
   public ResponseEntity<DataResponse<MemberSimpleInfoResponse>> guestLogin() {
 
@@ -49,7 +52,10 @@ public class MemberController {
   /**
    * 유저가 자기 자신의 정보에 대해 알 수 있다.
    */
-  @ApiOperation(value = "내 정보 조회")
+  @ApiOperation(
+      value = "내 정보 조회",
+      notes = "마이 페이지에서 사용자의 정보를 볼 수 있습니다.")
+  @PreAuthorize("isAuthenticated()")
   @GetMapping("/api/v1/member")
   public ResponseEntity<DataResponse<MemberInfoResponseDto>> getMember(
       @AuthenticationPrincipal SessionUser sessionUser
@@ -62,8 +68,10 @@ public class MemberController {
   /**
    * 로그인 요청을 통해 인가코드를 redirect url로 발급 가능
    */
-  @ApiOperation(value = "인가 코드 발급")
-  @GetMapping("/api/v1/login/kakao")
+  @ApiOperation(
+      value = "인가 코드 발급",
+      notes = "해당 url을 통해 로그인 화면으로 넘어간 후, 사용자가 정보를 입력하면 redirect url에서 코드를 발급할 수 있습니다.")
+  @GetMapping("/api/v1/kakao/login")
   public ResponseEntity<HttpHeaders> getKakaoAuthCode()  {
     HttpHeaders httpHeaders = kakaoFeignService.kakaoLogin();
     return new ResponseEntity<>(httpHeaders, HttpStatus.SEE_OTHER);
@@ -72,7 +80,9 @@ public class MemberController {
   /**
    * 인가코드를 통해 accessToken 과 유저 정보를 가져온다.
    */
-  @ApiOperation(value = "카카오 계정 회원가입")
+  @ApiOperation(
+      value = "카카오 계정 회원가입",
+      notes = "인가 코드를 입력하고 요청보내면, 사용자의 정보를 저장한 후 사용자의 Id를 확인할 수 있습니다.")
   @PostMapping("/api/v1/kakao/signup")
   public ResponseEntity<DataResponse<MemberSimpleInfoResponse>> kakaoLogin(@RequestParam("code") String code) {
 

--- a/src/main/java/com/dnd/bbok/infra/swagger/SwaggerConfig.java
+++ b/src/main/java/com/dnd/bbok/infra/swagger/SwaggerConfig.java
@@ -1,24 +1,88 @@
 package com.dnd.bbok.infra.swagger;
 
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.prepost.PreAuthorize;
+import springfox.documentation.RequestHandler;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
+
+  //mock API
   @Bean
   public Docket api() {
     return new Docket(DocumentationType.OAS_30)
+        .groupName("Mock-API")
         .select()
-        .apis(RequestHandlerSelectors.basePackage("com.dnd.bbok.domain"))
+        .apis(RequestHandlerSelectors.basePackage("com.dnd.bbok.mock"))
         .paths(PathSelectors.any())
         .build()
         .apiInfo(apiInfo());
+  }
+
+  //Authorization이 필요없는 API
+  @Bean
+  public Docket nonSecuredApi() {
+    return new Docket(DocumentationType.OAS_30)
+        .groupName("Non-Security API")
+        .select()
+        .apis(withoutMethodAnnotation(PreAuthorize.class))
+        .apis(RequestHandlerSelectors.basePackage("com.dnd.bbok.domain.member"))
+        .build()
+        .apiInfo(apiInfo());
+  }
+
+  //Authorization이 필요한 API
+  @Bean
+  public Docket securedApi() {
+    return new Docket(DocumentationType.OAS_30)
+        .groupName("Security API")
+        .securityContexts(List.of(securityContext()))
+        .securitySchemes(List.of(apiKey()))
+        .select()
+        .apis(RequestHandlerSelectors.withMethodAnnotation(PreAuthorize.class))
+        .apis(RequestHandlerSelectors.basePackage("com.dnd.bbok.domain"))
+        .build()
+        .apiInfo(apiInfo());
+  }
+
+  public static Predicate<RequestHandler> withoutMethodAnnotation(
+      final Class<? extends Annotation> annotation) {
+    return input -> !input.isAnnotatedWith(annotation);
+  }
+
+  private SecurityContext securityContext(){
+    return SecurityContext.builder()
+        .securityReferences(defaultAuth())
+        .build();
+  }
+
+  private List<SecurityReference> defaultAuth(){
+    AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+    AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+    authorizationScopes[0] = authorizationScope;
+    return Arrays.asList(new SecurityReference("Authorization", authorizationScopes));
+  }
+
+  // 버튼 클릭 시 입력 값 설정
+  private ApiKey apiKey(){
+    return new ApiKey("Authorization", "Bearer", "header");
   }
 
   private ApiInfo apiInfo() {
@@ -28,4 +92,6 @@ public class SwaggerConfig {
         .version("1.0")
         .build();
   }
+
+
 }

--- a/src/main/java/com/dnd/bbok/mock/ChecklistMockController.java
+++ b/src/main/java/com/dnd/bbok/mock/ChecklistMockController.java
@@ -1,4 +1,4 @@
-package com.dnd.bbok.domain.checklist.controller;
+package com.dnd.bbok.mock;
 
 import com.dnd.bbok.domain.checklist.dto.request.MemberChecklistRequestDto;
 import com.dnd.bbok.domain.checklist.dto.response.BasicChecklistDto;

--- a/src/main/java/com/dnd/bbok/mock/DiaryMockController.java
+++ b/src/main/java/com/dnd/bbok/mock/DiaryMockController.java
@@ -1,4 +1,4 @@
-package com.dnd.bbok.domain.diary.controller;
+package com.dnd.bbok.mock;
 
 import com.dnd.bbok.domain.diary.dto.request.DiaryRequestDto;
 import com.dnd.bbok.domain.diary.dto.response.*;

--- a/src/main/java/com/dnd/bbok/mock/FriendMockController.java
+++ b/src/main/java/com/dnd/bbok/mock/FriendMockController.java
@@ -1,4 +1,4 @@
-package com.dnd.bbok.domain.friend.controller;
+package com.dnd.bbok.mock;
 
 import com.dnd.bbok.domain.checklist.dto.request.ChecklistInfoRequestDto;
 import com.dnd.bbok.domain.checklist.dto.response.MyChecklistDto;

--- a/src/main/java/com/dnd/bbok/mock/SayingMockController.java
+++ b/src/main/java/com/dnd/bbok/mock/SayingMockController.java
@@ -1,4 +1,4 @@
-package com.dnd.bbok.domain.saying.controller;
+package com.dnd.bbok.mock;
 
 import com.dnd.bbok.domain.saying.dto.request.BookmarkRequestDto;
 import com.dnd.bbok.domain.saying.dto.response.BookmarkInfoDto;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -24,5 +24,5 @@ oauth2:
     infoUrl: https://kapi.kakao.com
     baseUrl: https://kauth.kakao.com
     clientId: 3fca0db05482af0333a5fb5b9dc5b345
-    redirectUri: http://localhost:8080/api/v1/account/kakao/result
+    redirectUri: https://bbok.kro.kr/api/v1/account/kakao/result
     secretKey: ${SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,4 @@
 # active를 dev로 바꾸면 됩니다!
 spring:
   profiles:
-    active: dev
+    active: prod


### PR DESCRIPTION
## What is this PR? 🔍
- Swagger config를 변경하여 API docs가 나타나는 것에 변화를 줬습니다.

## Key Changes 📝
- [X] mock API, security API, non-security API 로 그룹화하였습니다. 
![image](https://github.com/dnd-side-project/dnd-9th-10-backend/assets/94590894/25abc476-06d0-4b46-a46e-87910256826e)
- [X] mock API만 따로 매핑이 쉽도록 mockController의 위치를 `com/dnd/bbok/mock` 로 옮겨줬습니다.
- [X] security와 non-security의 차이는 아래 Authorization 버튼 여부입니다.
![image](https://github.com/dnd-side-project/dnd-9th-10-backend/assets/94590894/03b462b6-0ea3-4eb9-b363-93083b546fa0)

## Test Checklist ✅
- [X] Nothing

## To Reviewers
dev.yml 파일은 git에 올리지 않고 따로 구상해서 슬랙 DM으로 전달해드리도록 하겠습니다!