### PR TITLE
feat: 토큰 재발급 Api 구현

### DIFF
--- a/src/main/java/com/dnd/bbok/domain/jwt/controller/JwtController.java
+++ b/src/main/java/com/dnd/bbok/domain/jwt/controller/JwtController.java
@@ -1,0 +1,33 @@
+package com.dnd.bbok.domain.jwt.controller;
+
+import static com.dnd.bbok.domain.member.service.MemberSignUpService.setCookieAndHeader;
+
+import com.dnd.bbok.domain.jwt.dto.ReIssueTokenDto;
+import com.dnd.bbok.domain.jwt.service.JwtTokenReissueService;
+import com.dnd.bbok.global.response.MessageResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Api(tags = "토큰 관련 컨트롤러")
+public class JwtController {
+  private final JwtTokenReissueService jwtTokenReissueService;
+
+  @GetMapping("/api/v1/jwt/refresh")
+  @ApiOperation(value = "Jwt 재발급", notes = "Jwt를 재발급 할 수 있습니다.")
+  public ResponseEntity<MessageResponse> reIssueToken(@CookieValue(name = "refreshToken") String refreshToken) {
+    ReIssueTokenDto reIssueTokenDto = jwtTokenReissueService.reIssueToken(refreshToken);
+    HttpHeaders headers = setCookieAndHeader(reIssueTokenDto);
+    return new ResponseEntity<>(
+        MessageResponse.of(HttpStatus.CREATED, "Token 재발급 성공"), headers, HttpStatus.CREATED);
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/domain/jwt/dto/ReIssueTokenDto.java
+++ b/src/main/java/com/dnd/bbok/domain/jwt/dto/ReIssueTokenDto.java
@@ -1,0 +1,16 @@
+package com.dnd.bbok.domain.jwt.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReIssueTokenDto {
+
+  private final String refreshToken;
+
+  private final String accessToken;
+
+  public ReIssueTokenDto(String accessToken, String refreshToken) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+  }
+}

--- a/src/main/java/com/dnd/bbok/domain/jwt/dto/SessionUser.java
+++ b/src/main/java/com/dnd/bbok/domain/jwt/dto/SessionUser.java
@@ -1,4 +1,4 @@
-package com.dnd.bbok.global.jwt;
+package com.dnd.bbok.domain.jwt.dto;
 
 import com.dnd.bbok.domain.member.entity.Member;
 import java.io.Serializable;

--- a/src/main/java/com/dnd/bbok/domain/jwt/exception/JwtException.java
+++ b/src/main/java/com/dnd/bbok/domain/jwt/exception/JwtException.java
@@ -1,4 +1,4 @@
-package com.dnd.bbok.global.jwt;
+package com.dnd.bbok.domain.jwt.exception;
 
 import com.dnd.bbok.global.exception.ErrorCode;
 

--- a/src/main/java/com/dnd/bbok/domain/jwt/filter/JwtAuthenticationEntryPointHandler.java
+++ b/src/main/java/com/dnd/bbok/domain/jwt/filter/JwtAuthenticationEntryPointHandler.java
@@ -1,4 +1,4 @@
-package com.dnd.bbok.global.jwt;
+package com.dnd.bbok.domain.jwt.filter;
 
 import static com.dnd.bbok.global.exception.ErrorCode.RESOURCE_UNAUTHORIZED;
 

--- a/src/main/java/com/dnd/bbok/domain/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/bbok/domain/jwt/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,8 @@
-package com.dnd.bbok.global.jwt;
+package com.dnd.bbok.domain.jwt.filter;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
+import com.dnd.bbok.domain.jwt.service.JwtTokenProvider;
 import java.io.IOException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;

--- a/src/main/java/com/dnd/bbok/domain/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/dnd/bbok/domain/jwt/filter/JwtExceptionFilter.java
@@ -1,5 +1,6 @@
-package com.dnd.bbok.global.jwt;
+package com.dnd.bbok.domain.jwt.filter;
 
+import com.dnd.bbok.domain.jwt.exception.JwtException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.dnd.bbok.global.exception.ErrorResponse;
 import java.io.IOException;

--- a/src/main/java/com/dnd/bbok/domain/jwt/service/JwtTokenProvider.java
+++ b/src/main/java/com/dnd/bbok/domain/jwt/service/JwtTokenProvider.java
@@ -1,5 +1,6 @@
-package com.dnd.bbok.global.jwt;
+package com.dnd.bbok.domain.jwt.service;
 
+import com.dnd.bbok.domain.jwt.dto.SessionUser;
 import com.dnd.bbok.domain.member.entity.Member;
 import com.dnd.bbok.domain.member.entity.Role;
 import com.dnd.bbok.domain.member.repository.MemberRepository;
@@ -17,6 +18,8 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import java.security.Key;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
@@ -47,7 +50,7 @@ public class JwtTokenProvider {
       + "HJ3oMvI61Id26fdQHgWE1QMLcrhOmRzTxkCU+gesx5ANkSSIrPHNswIDAQAB";
 
   //accessToken 만료시간
-  public static final Long ACCESS_TOKEN_EXPIRE_LENGTH_MS = 1000L * 60 * 60; // 1hour
+  public static final Long ACCESS_TOKEN_EXPIRE_LENGTH_MS = 1000L * 60 * 60 * 24; //1일
 
   //refreshToken 만료시간
   public static final Long REFRESH_TOKEN_EXPIRE_LENGTH_MS = 1000L * 60 * 60 * 24 * 14; //2주
@@ -144,5 +147,17 @@ public class JwtTokenProvider {
   }
 
 
+  public boolean isTokenExpirationSafe(String token) {
+    Instant expiration = extractAllClaims(token).getExpiration().toInstant();
+    Instant now = Instant.now();
+    return hasTokenExpMoreThanThreeDays(expiration, now);
+  }
 
+  private boolean hasTokenExpMoreThanThreeDays(Instant expiration, Instant now) {
+    return (Duration.between(now, expiration).compareTo(Duration.ofDays(3)) >= 0);
+  }
+
+  public void saveRefreshTokenInRedis(Member member, String refreshToken) {
+    refreshTokenRepository.save(new RefreshToken(member.getId(), refreshToken));
+  }
 }

--- a/src/main/java/com/dnd/bbok/domain/jwt/service/JwtTokenReissueService.java
+++ b/src/main/java/com/dnd/bbok/domain/jwt/service/JwtTokenReissueService.java
@@ -1,0 +1,37 @@
+package com.dnd.bbok.domain.jwt.service;
+
+import com.dnd.bbok.domain.jwt.dto.ReIssueTokenDto;
+import com.dnd.bbok.domain.member.entity.Member;
+import com.dnd.bbok.domain.member.service.MemberService;
+import com.dnd.bbok.infra.redis.RedisService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 토큰을 재발행할 수 있는 서비스.
+ * refreshToken 이 3일이상 남으면 accessToken 만 발급합니다.
+ * refreshToken 만료기간이 3일보다 적게 남으면 accessToken과 refreshToken 모두 발급합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class JwtTokenReissueService {
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final RedisService redisService;
+  private final MemberService memberService;
+
+  public ReIssueTokenDto reIssueToken(String refreshToken) {
+    UUID memberId = redisService.findMemberByToken(refreshToken);
+    Member member = memberService.getMemberById(memberId);
+    String newAccessToken = jwtTokenProvider.createAccessToken(memberId, member.getRole());
+
+    if(jwtTokenProvider.isTokenExpirationSafe(refreshToken)) {
+      return new ReIssueTokenDto(newAccessToken, refreshToken);
+    }
+    String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
+    redisService.saveRefreshToken(memberId, newRefreshToken);
+    return new ReIssueTokenDto(newAccessToken, newRefreshToken);
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/bbok/domain/member/controller/MemberController.java
@@ -1,11 +1,13 @@
 package com.dnd.bbok.domain.member.controller;
 
+import static com.dnd.bbok.domain.member.service.MemberSignUpService.setCookieAndHeader;
+
 import com.dnd.bbok.domain.member.dto.response.LoginResponseDto;
 import com.dnd.bbok.domain.member.dto.response.MemberInfoResponseDto;
 import com.dnd.bbok.domain.member.dto.response.MemberSimpleInfoResponse;
 import com.dnd.bbok.domain.member.service.MemberInfoService;
 import com.dnd.bbok.domain.member.service.MemberSignUpService;
-import com.dnd.bbok.global.jwt.SessionUser;
+import com.dnd.bbok.domain.jwt.dto.SessionUser;
 import com.dnd.bbok.global.response.DataResponse;
 import com.dnd.bbok.infra.feign.dto.response.KakaoUserInfoResponseDto;
 import com.dnd.bbok.infra.feign.service.KakaoFeignService;
@@ -43,7 +45,7 @@ public class MemberController {
   public ResponseEntity<DataResponse<MemberSimpleInfoResponse>> guestLogin() {
 
     LoginResponseDto guestLoginResponse = memberSignUpService.loginGuestMember();
-    HttpHeaders headers = memberSignUpService.setCookieAndHeader(guestLoginResponse);
+    HttpHeaders headers = setCookieAndHeader(guestLoginResponse);
 
     return new ResponseEntity<>(DataResponse.of(HttpStatus.CREATED,
         "게스트 회원 가입 성공", guestLoginResponse.getMember()), headers, HttpStatus.CREATED);
@@ -89,7 +91,7 @@ public class MemberController {
     //코드를 통해 액세스 토큰 발급한 후, 유저 정보를 가져온다.
     KakaoUserInfoResponseDto kakaoUserInfo = kakaoFeignService.getKakaoInfoWithToken(code);
     LoginResponseDto kakaoLoginResponse = memberSignUpService.loginKakaoMember(kakaoUserInfo);
-    HttpHeaders headers = memberSignUpService.setCookieAndHeader(kakaoLoginResponse);
+    HttpHeaders headers = setCookieAndHeader(kakaoLoginResponse);
 
     return new ResponseEntity<>(
         DataResponse.of(

--- a/src/main/java/com/dnd/bbok/domain/member/service/MemberInfoService.java
+++ b/src/main/java/com/dnd/bbok/domain/member/service/MemberInfoService.java
@@ -1,10 +1,7 @@
 package com.dnd.bbok.domain.member.service;
 
-import static com.dnd.bbok.global.exception.ErrorCode.MEMBER_NOT_FOUND;
-
 import com.dnd.bbok.domain.member.dto.response.MemberInfoResponseDto;
 import com.dnd.bbok.domain.member.entity.Member;
-import com.dnd.bbok.domain.member.exception.MemberNotFoundException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,8 +13,7 @@ public class MemberInfoService {
   private final MemberService memberService;
 
   public MemberInfoResponseDto getMember(UUID memberId) {
-    Member member = memberService.getMemberById(memberId)
-        .orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
+    Member member = memberService.getMemberById(memberId);
     return new MemberInfoResponseDto(member);
   }
 }

--- a/src/main/java/com/dnd/bbok/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/bbok/domain/member/service/MemberService.java
@@ -1,8 +1,11 @@
 package com.dnd.bbok.domain.member.service;
 
+import static com.dnd.bbok.global.exception.ErrorCode.*;
+
 import com.dnd.bbok.domain.member.entity.Member;
 import com.dnd.bbok.domain.member.entity.OAuth2Provider;
 import com.dnd.bbok.domain.member.entity.Role;
+import com.dnd.bbok.domain.member.exception.MemberNotFoundException;
 import com.dnd.bbok.domain.member.repository.MemberRepository;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,8 +20,7 @@ public class MemberService {
   private final MemberRepository memberRepository;
 
   public Member saveGuestMember() {
-    Member guest = createGuestMember();
-    return memberRepository.save(guest);
+    return memberRepository.save(createGuestMember());
   }
 
   private Member createGuestMember() {
@@ -41,8 +43,9 @@ public class MemberService {
     return memberRepository.save(member);
   }
 
-  public Optional<Member> getMemberById(UUID uuid) {
+  public Member getMemberById(UUID uuid) {
     log.info("해당 uuid를 가진 멤버를 찾습니다.");
-    return memberRepository.findById(uuid);
+    return memberRepository.findById(uuid)
+        .orElseThrow(()->new MemberNotFoundException(MEMBER_NOT_FOUND));
   }
 }

--- a/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
@@ -19,7 +19,10 @@ public enum ErrorCode {
   RESOURCE_FORBIDDEN(HttpStatus.FORBIDDEN, "R001", "해당 리소스에 대한 권한이 없습니다."),
 
   // Member
-  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 uuid를 가진 멤버를 찾을 수 없습니다.");
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 uuid를 가진 멤버를 찾을 수 없습니다."),
+
+  // JWT
+  REFRESH_JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "J003", "만료된 리프레시 토큰입니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/dnd/bbok/global/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/bbok/global/security/SecurityConfig.java
@@ -1,8 +1,8 @@
 package com.dnd.bbok.global.security;
 
-import com.dnd.bbok.global.jwt.JwtAuthenticationFilter;
-import com.dnd.bbok.global.jwt.JwtExceptionFilter;
-import com.dnd.bbok.global.jwt.JwtAuthenticationEntryPointHandler;
+import com.dnd.bbok.domain.jwt.filter.JwtAuthenticationFilter;
+import com.dnd.bbok.domain.jwt.filter.JwtExceptionFilter;
+import com.dnd.bbok.domain.jwt.filter.JwtAuthenticationEntryPointHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;

--- a/src/main/java/com/dnd/bbok/global/util/CookieUtil.java
+++ b/src/main/java/com/dnd/bbok/global/util/CookieUtil.java
@@ -1,6 +1,6 @@
 package com.dnd.bbok.global.util;
 
-import static com.dnd.bbok.global.jwt.JwtTokenProvider.REFRESH_TOKEN_EXPIRE_LENGTH_MS;
+import static com.dnd.bbok.domain.jwt.service.JwtTokenProvider.REFRESH_TOKEN_EXPIRE_LENGTH_MS;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -26,17 +26,5 @@ public class CookieUtil {
         .build();
 
     httpHeaders.add(HttpHeaders.SET_COOKIE, cookie.toString());
-  }
-
-  public static void resetRefreshToken(HttpHeaders headers) {
-    ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
-        .httpOnly(true)
-        .secure(true)
-        .maxAge(0)
-        .path("/")
-        .sameSite("None")
-        .build();
-
-    headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
   }
 }

--- a/src/main/java/com/dnd/bbok/infra/redis/RedisService.java
+++ b/src/main/java/com/dnd/bbok/infra/redis/RedisService.java
@@ -1,0 +1,31 @@
+package com.dnd.bbok.infra.redis;
+
+import static com.dnd.bbok.global.exception.ErrorCode.REFRESH_JWT_EXPIRED;
+
+import com.dnd.bbok.domain.jwt.exception.JwtException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * refreshToken 관리를 위한 Redis 관련 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  @Transactional
+  public void saveRefreshToken(UUID memberId, String refreshToken) {
+    refreshTokenRepository.save(new RefreshToken(memberId, refreshToken));
+  }
+
+  @Transactional(readOnly = true)
+  public UUID findMemberByToken(String refreshToken) {
+    RefreshToken token = refreshTokenRepository.findByRefreshToken(refreshToken)
+        .orElseThrow(() -> new JwtException(REFRESH_JWT_EXPIRED));
+    return token.getMemberId();
+  }
+}

--- a/src/main/java/com/dnd/bbok/infra/redis/RefreshToken.java
+++ b/src/main/java/com/dnd/bbok/infra/redis/RefreshToken.java
@@ -1,15 +1,26 @@
 package com.dnd.bbok.infra.redis;
 
 import java.util.UUID;
+import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
 
-@RedisHash(value = "memberId", timeToLive = 1000L * 60 * 60 * 24 * 14)
+@RedisHash(value = "refreshToken", timeToLive = 1000L * 60 * 60 * 24 * 14)
+@Getter
 public class RefreshToken {
 
+  /**
+   * 사용자의 Id
+   */
   @Id
-  private UUID memberId;
-  private String refreshToken;
+  private final UUID memberId;
+
+  /**
+   * 사용자가 가지고 있는 refreshToken
+   */
+  @Indexed
+  private final String refreshToken;
 
   public RefreshToken(UUID memberId, String refreshToken) {
     this.memberId = memberId;

--- a/src/main/java/com/dnd/bbok/infra/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/dnd/bbok/infra/redis/RefreshTokenRepository.java
@@ -1,5 +1,6 @@
 package com.dnd.bbok.infra.redis;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.repository.CrudRepository;
@@ -7,6 +8,5 @@ import org.springframework.data.repository.CrudRepository;
 @EnableRedisRepositories
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, UUID> {
 
-
-
+  Optional<RefreshToken> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/dnd/bbok/infra/swagger/SwaggerConfig.java
+++ b/src/main/java/com/dnd/bbok/infra/swagger/SwaggerConfig.java
@@ -43,7 +43,7 @@ public class SwaggerConfig {
         .groupName("Non-Security API")
         .select()
         .apis(withoutMethodAnnotation(PreAuthorize.class))
-        .apis(RequestHandlerSelectors.basePackage("com.dnd.bbok.domain.member"))
+        .apis(RequestHandlerSelectors.basePackage("com.dnd.bbok.domain"))
         .build()
         .apiInfo(apiInfo());
   }


### PR DESCRIPTION
## What is this PR? 🔍
- AccessToken이 만료되면, refresh token으로 재발급할 수 있는 기능 구현
- Close #21 

## Key Changes 📝
- [X] jwt 상위 패키지를 global에서 domain으로 변경
- [X] swagger config에서 no-security api 의 base package를 member가 아닌 domain으로 확장
- [X] 재발급 기능 구현
- [X] access token의 만료기간을 1시간에서 1일로 설정

## Test Checklist ✅
- Nothing

## To Reviewers
코드 리팩토링이 확실히 필요하다고 느꼈으나, 시간이 너무 늦어.. 일단 PR 올려놓겠습니다🥲