### PR TITLE
feat: 친구 캐릭터 생성 기능 구현

### DIFF
--- a/src/main/java/com/dnd/bbok/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/controller/FriendController.java
@@ -1,15 +1,22 @@
 package com.dnd.bbok.domain.friend.controller;
 
+import com.dnd.bbok.domain.friend.dto.request.FriendRequestDto;
 import com.dnd.bbok.domain.friend.dto.response.BbokCharactersDto;
+import com.dnd.bbok.domain.friend.service.MemberFriendUseCaseService;
 import com.dnd.bbok.domain.friend.service.IconService;
+import com.dnd.bbok.domain.jwt.dto.SessionUser;
 import com.dnd.bbok.global.response.DataResponse;
+import com.dnd.bbok.global.response.MessageResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FriendController {
 
   private final IconService iconService;
+  private final MemberFriendUseCaseService memberFriendUseCaseService;
 
   @ApiOperation(value = "캐릭터 정보 제공")
   @GetMapping("/character")
@@ -30,5 +38,15 @@ public class FriendController {
         DataResponse.of(HttpStatus.OK, "캐릭터 목록 제공 성공", characters), HttpStatus.OK);
   }
 
+  @ApiOperation(value = "친구 등록")
+  @PostMapping("/friend")
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<MessageResponse> createFriend(
+      @AuthenticationPrincipal SessionUser sessionUser,
+      @RequestBody FriendRequestDto requestFriend) {
+    memberFriendUseCaseService.createFriendCharacter(sessionUser.getUuid(), requestFriend);
+    return new ResponseEntity<>(
+        MessageResponse.of(HttpStatus.CREATED, "친구 등록 성공"), HttpStatus.CREATED);
+  }
 
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/dto/request/FriendRequestDto.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/dto/request/FriendRequestDto.java
@@ -1,5 +1,11 @@
 package com.dnd.bbok.domain.friend.dto.request;
 
+import static com.dnd.bbok.global.exception.ErrorCode.CHARACTER_NOT_FOUND;
+
+import com.dnd.bbok.domain.friend.entity.BbokCharacter;
+import com.dnd.bbok.domain.friend.entity.Friend;
+import com.dnd.bbok.domain.friend.exception.CharacterNotFoundException;
+import com.dnd.bbok.domain.member.entity.Member;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,5 +23,28 @@ public class FriendRequestDto {
   @ApiModelProperty(value = "친구 캐릭터")
   private String character;
 
-
+  public Friend toEntity(Member member) {
+    return Friend.builder()
+        .active(true)
+        .name(name)
+        .bbok(changeType(character))
+        .friendScore(0L)
+        .member(member)
+        .build();
+  }
+  
+  private BbokCharacter changeType(String character) {
+    BbokCharacter bbok;
+    switch (character) {
+      case "CACTUS":
+        bbok = BbokCharacter.SIDE_CACTUS;
+        break;
+      case "HEDGEHOG":
+        bbok = BbokCharacter.SIDE_HEDGEHOG;
+        break;
+      default:
+        throw new CharacterNotFoundException(CHARACTER_NOT_FOUND);
+    }
+    return bbok;
+  }
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/entity/Friend.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/entity/Friend.java
@@ -13,10 +13,13 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Friend extends BaseTimeEntity {
 
   @Id
@@ -29,7 +32,7 @@ public class Friend extends BaseTimeEntity {
   @NotNull
   private String name;
 
-  private boolean status;
+  private boolean active;
 
   @NotNull
   private Long friendScore;
@@ -40,5 +43,14 @@ public class Friend extends BaseTimeEntity {
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "member_id")
   private Member member;
+
+  @Builder
+  public Friend(BbokCharacter bbok, String name, boolean active, Long friendScore, Member member) {
+    this.bbok = bbok;
+    this.name = name;
+    this.active = active;
+    this.friendScore = friendScore;
+    this.member = member;
+  }
 
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/exception/CharacterNotFoundException.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/exception/CharacterNotFoundException.java
@@ -1,0 +1,10 @@
+package com.dnd.bbok.domain.friend.exception;
+
+import com.dnd.bbok.global.exception.BusinessException;
+import com.dnd.bbok.global.exception.ErrorCode;
+
+public class CharacterNotFoundException extends BusinessException {
+  public CharacterNotFoundException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/dnd/bbok/domain/friend/exception/FriendCreationException.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/exception/FriendCreationException.java
@@ -1,0 +1,12 @@
+package com.dnd.bbok.domain.friend.exception;
+
+import com.dnd.bbok.global.exception.BusinessException;
+import com.dnd.bbok.global.exception.ErrorCode;
+
+public class FriendCreationException extends BusinessException {
+
+  public FriendCreationException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/repository/FriendRepository.java
@@ -1,0 +1,14 @@
+package com.dnd.bbok.domain.friend.repository;
+
+import com.dnd.bbok.domain.friend.entity.Friend;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+  @Query("select f from Friend f where f.member.id = :memberId")
+  List<Friend> findOtherFriend(@Param("memberId") UUID memberId);
+}

--- a/src/main/java/com/dnd/bbok/domain/friend/service/FriendService.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/service/FriendService.java
@@ -1,0 +1,37 @@
+package com.dnd.bbok.domain.friend.service;
+
+import static com.dnd.bbok.global.exception.ErrorCode.OTHER_FRIEND_ALREADY_ACTIVE;
+
+import com.dnd.bbok.domain.friend.entity.Friend;
+import com.dnd.bbok.domain.friend.exception.FriendCreationException;
+import com.dnd.bbok.domain.friend.repository.FriendRepository;
+import com.dnd.bbok.domain.member.entity.Member;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FriendService {
+
+  private final FriendRepository friendRepository;
+
+  @Transactional
+  public void saveFriend(Friend friend) {
+    friendRepository.save(friend);
+  }
+
+
+  @Transactional(readOnly = true)
+  public void checkOtherActiveFriend(Member member) {
+    List<Friend> otherFriends = friendRepository.findOtherFriend(member.getId());
+    for(Friend each : otherFriends) {
+      if(each.isActive()) {
+        throw new FriendCreationException(OTHER_FRIEND_ALREADY_ACTIVE);
+      }
+    }
+  }
+}

--- a/src/main/java/com/dnd/bbok/domain/friend/service/MemberFriendUseCaseService.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/service/MemberFriendUseCaseService.java
@@ -1,0 +1,26 @@
+package com.dnd.bbok.domain.friend.service;
+
+import com.dnd.bbok.domain.friend.dto.request.FriendRequestDto;
+import com.dnd.bbok.domain.member.entity.Member;
+import com.dnd.bbok.domain.member.service.MemberService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 친구 관련 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class MemberFriendUseCaseService {
+
+  private final FriendService friendService;
+  private final MemberService memberService;
+
+  public void createFriendCharacter(UUID memberId, FriendRequestDto requestFriend) {
+    Member member = memberService.getMemberById(memberId);
+    //2. member가 활성화된 다른 친구를 가지고 있는지 체크해야 한다.
+    friendService.checkOtherActiveFriend(member);
+    friendService.saveFriend(requestFriend.toEntity(member));
+  }
+}

--- a/src/main/java/com/dnd/bbok/domain/member/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/dnd/bbok/domain/member/dto/response/LoginResponseDto.java
@@ -12,13 +12,13 @@ public class LoginResponseDto {
   @ApiModelProperty("발급된 리프레쉬 토큰")
   private final String refreshToken;
 
-  @ApiModelProperty("멤버의 id만 반환되는 dto")
-  private final MemberSimpleInfoResponse member;
+  @ApiModelProperty("멤버의 id")
+  private final String memberId;
 
-  public LoginResponseDto(String accessToken, String refreshToken, MemberSimpleInfoResponse member) {
+  public LoginResponseDto(String accessToken, String refreshToken, String memberId) {
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
-    this.member = member;
+    this.memberId = memberId;
   }
 
 }

--- a/src/main/java/com/dnd/bbok/domain/member/service/MemberSignUpService.java
+++ b/src/main/java/com/dnd/bbok/domain/member/service/MemberSignUpService.java
@@ -1,7 +1,6 @@
 package com.dnd.bbok.domain.member.service;
 
 import com.dnd.bbok.domain.jwt.dto.ReIssueTokenDto;
-import com.dnd.bbok.domain.member.dto.response.MemberSimpleInfoResponse;
 import com.dnd.bbok.global.util.CookieUtil;
 import com.dnd.bbok.global.util.HttpHeaderUtil;
 import com.dnd.bbok.infra.feign.dto.response.KakaoUserInfoResponseDto;
@@ -55,7 +54,7 @@ public class MemberSignUpService {
 
     // refreshToken은 redis에 따로 저장해둔다.
     jwtTokenProvider.saveRefreshTokenInRedis(member, refreshToken);
-    return new LoginResponseDto(accessToken, refreshToken, new MemberSimpleInfoResponse(member));
+    return new LoginResponseDto(accessToken, refreshToken, member.getId().toString());
   }
 
   private Member signUp(KakaoUserInfoResponseDto kakaoUserInfo) {

--- a/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
@@ -21,8 +21,14 @@ public enum ErrorCode {
   // Member
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 uuid를 가진 멤버를 찾을 수 없습니다."),
 
+  // Friend
+  CHARACTER_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "해당 이름을 가진 캐릭터를 찾을 수 없습니다."),
+  OTHER_FRIEND_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "F002", "동시에 2명 이상의 친구를 생성할 수 없습니다."),
+
   // JWT
   REFRESH_JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "J003", "만료된 리프레시 토큰입니다.");
+
+
 
   private final HttpStatus status;
   private final String code;

--- a/src/main/java/com/dnd/bbok/global/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/bbok/global/security/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.cors() //cors 설정 활성화
+    http.cors()
         .and()
         .csrf().disable() //CSRF 보호 기능 비활성화
         .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
@@ -31,6 +31,7 @@ public class SecurityConfig {
     http//HTTP 헤더에 사용자의 이름과 암호 포함을 비활성화
         .authorizeRequests()
         .antMatchers(HttpMethod.GET, "/test", "/api/v1/member", "/api/v1/checklist", "/api/v1/character").authenticated() //해당 요청은 인증이 필요하다.
+        .antMatchers(HttpMethod.POST, "/friend").authenticated()
         .antMatchers("/**").permitAll() //해당 요청은 누구나 다 들어올 수 있다.
         .and()
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/dnd/bbok/mock/FriendMockController.java
+++ b/src/main/java/com/dnd/bbok/mock/FriendMockController.java
@@ -2,7 +2,6 @@ package com.dnd.bbok.mock;
 
 import com.dnd.bbok.domain.checklist.dto.request.ChecklistInfoRequestDto;
 import com.dnd.bbok.domain.checklist.dto.response.MyChecklistDto;
-import com.dnd.bbok.domain.friend.dto.request.FriendRequestDto;
 import com.dnd.bbok.domain.friend.dto.response.FriendsDto;
 import com.dnd.bbok.global.response.DataResponse;
 import com.dnd.bbok.global.response.MessageResponse;
@@ -12,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,13 +28,6 @@ public class FriendMockController {
         DataResponse.of(HttpStatus.OK, "친구 목록 조회 성공", friends), HttpStatus.OK);
   }
 
-  @ApiOperation(value = "친구 등록")
-  @PostMapping("/friend")
-  public ResponseEntity<MessageResponse> createFriend(
-      @RequestBody FriendRequestDto requestFriend) {
-    return new ResponseEntity<>(
-        MessageResponse.of(HttpStatus.CREATED, "친구 등록 성공"), HttpStatus.CREATED);
-  }
 
   @ApiOperation(value = "나만의 기준 조회")
   @GetMapping("/friend/checklist")


### PR DESCRIPTION
## What is this PR? 🔍
- 로그인한 사용자가 친구 캐릭터를 등록할 수 있는 기능, API 구현
- Close #18 

## Key Changes 📝
- [X] Friend 엔티티의 필드 중, 활성화 상태 변수명을 status에서 active로 변경
- [X] 캐릭터 이름(CACTUS, HEDGEHOG 중 1)외에 잘못 요청할 경우 예외 처리
- [X] 친구를 2명 동시에 등록할 경우 예외 처리

## Test Checklist ✅
- Nothing

## To Reviewers
- 로그인 response body 수정은 기존에 member 응답객체에 감싸서 보냈는데, memberId만 반환하게끔 다시 수정했습니다. 
- 초반에 친구를 입력할 때만 정면을 보는 캐릭터이고, 친구 카드에서는 측면을 보는 캐릭터여서 
DB에 측면을 바라보는 친구(side_캐릭터) enum값으로 저장했습니다.
- 성공한 경우
![image](https://github.com/dnd-side-project/dnd-9th-10-backend/assets/94590894/ea527f36-cbe6-4bfd-bedc-d56bd34279af)

- 동시에 2명 이상 등록하려는 경우
![image](https://github.com/dnd-side-project/dnd-9th-10-backend/assets/94590894/aeadc0ce-24cd-4e94-8f7a-0c615e6a4f13)

- 요청 body에서 이름을 잘못 입력한 경우
![image](https://github.com/dnd-side-project/dnd-9th-10-backend/assets/94590894/f6a98e6e-1dd3-4119-9dc7-48d5229e5e35)
