### PR TITLE
refactor: jwt 관련 서버 에러 정의, CORS allowed origin 추가

### DIFF
--- a/src/main/java/com/dnd/bbok/ServerApplication.java
+++ b/src/main/java/com/dnd/bbok/ServerApplication.java
@@ -23,7 +23,10 @@ public class ServerApplication {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
-						.allowedOrigins("http://localhost:3000", "https://bbok.kro.kr");
+						.allowedOrigins(
+								"http://localhost:3000",
+								"https://bbok.vercel.app",
+								"https://bbok.kro.kr");
 			}
 		};
 	}

--- a/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
@@ -28,7 +28,9 @@ public enum ErrorCode {
   // Diary
   INVALID_MEMBER_CHECKLIST_ID(HttpStatus.BAD_REQUEST, "D001","Member Checklist Id가 올바르지 않습니다."),
   // JWT
-  REFRESH_JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "J003", "만료된 리프레시 토큰입니다.");
+  REFRESH_JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "J001", "만료된 리프레시 토큰입니다."),
+  JWT_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "J002", "유효하지 않은 토큰입니다."),
+  JWT_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "J003", "만료된 토큰입니다.");
 
 
 


### PR DESCRIPTION
## What is this PR? 🔍
- JWT 관련 서버 에러 정의, CORS allowed origin 추가했습니다.
- Close #35, #36, #38 

## Key Changes 📝
- `JWT 관련 에러코드 명시`
  REFRESH_JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "J001", "만료된 리프레시 토큰입니다.")

  JWT_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "J002", "유효하지 않은 토큰입니다.")

  JWT_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "J003", "만료된 토큰입니다.")
  
![image](https://github.com/dnd-side-project/dnd-9th-10-backend/assets/94590894/f3949be3-bcb9-44b0-a7a7-f1b7226f1bbf)


## Test Checklist ✅
- Nothing

## To Reviewers
- Nothing