### PR TITLE
[Feature/#23] 일기 조회 / 친구별 태그 조회 api 구현

### DIFF
--- a/src/main/java/com/dnd/bbok/domain/checklist/repository/DiaryChecklistRepository.java
+++ b/src/main/java/com/dnd/bbok/domain/checklist/repository/DiaryChecklistRepository.java
@@ -2,7 +2,11 @@ package com.dnd.bbok.domain.checklist.repository;
 
 import com.dnd.bbok.domain.checklist.entity.DiaryChecklist;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface DiaryChecklistRepository extends JpaRepository<DiaryChecklist, Long> {
-
+    @Query("SELECT dc FROM DiaryChecklist dc JOIN FETCH dc.diary JOIN FETCH dc.memberChecklist WHERE dc.diary.id IN :diaryIds")
+    List<DiaryChecklist> getDiaryChecklistByDiaryIds(List<Long> diaryIds);
 }

--- a/src/main/java/com/dnd/bbok/domain/checklist/service/DiaryChecklistEntityService.java
+++ b/src/main/java/com/dnd/bbok/domain/checklist/service/DiaryChecklistEntityService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Diary Checklist Entity 관련한 DB 작업을 수행하는 서비스
@@ -20,11 +21,14 @@ public class DiaryChecklistEntityService {
     private final DiaryChecklistRepository diaryChecklistRepository;
 
     public void createDiaryChecklist(Diary diary, List<MemberChecklist> memberChecklist, List<ChecklistDto> checklistDtos) {
-        memberChecklist.forEach(checklist -> this.diaryChecklistRepository.save(DiaryChecklist.builder()
-                .diary(diary)
-                .isChecked((checklistDtos.stream().filter(ele -> Objects.equals(ele.getId(), checklist.getId())).findFirst().orElseThrow()).getIsChecked())
-                .memberChecklist(checklist)
-                .build()
-        ));
+
+        memberChecklist.forEach(checklist -> {
+            Optional<ChecklistDto> target = checklistDtos.stream().filter(ele -> Objects.equals(ele.getId(), checklist.getId())).findFirst();
+            target.ifPresent(checklistDto -> this.diaryChecklistRepository.save(DiaryChecklist.builder()
+                    .diary(diary)
+                    .isChecked(checklistDto.getIsChecked())
+                    .memberChecklist(checklist)
+                    .build()));
+        });
     }
 }

--- a/src/main/java/com/dnd/bbok/domain/checklist/service/DiaryChecklistEntityService.java
+++ b/src/main/java/com/dnd/bbok/domain/checklist/service/DiaryChecklistEntityService.java
@@ -31,4 +31,8 @@ public class DiaryChecklistEntityService {
                     .build()));
         });
     }
+
+    public List<DiaryChecklist> getDiaryChecklistByDiaryIds(List<Long> diaryIds) {
+        return this.diaryChecklistRepository.getDiaryChecklistByDiaryIds(diaryIds);
+    }
 }

--- a/src/main/java/com/dnd/bbok/domain/checklist/service/DiaryChecklistService.java
+++ b/src/main/java/com/dnd/bbok/domain/checklist/service/DiaryChecklistService.java
@@ -1,5 +1,6 @@
 package com.dnd.bbok.domain.checklist.service;
 
+import com.dnd.bbok.domain.checklist.entity.DiaryChecklist;
 import com.dnd.bbok.domain.checklist.entity.MemberChecklist;
 import com.dnd.bbok.domain.diary.dto.request.ChecklistDto;
 import com.dnd.bbok.domain.diary.entity.Diary;
@@ -27,5 +28,9 @@ public class DiaryChecklistService {
         }
 
         diaryChecklistEntityService.createDiaryChecklist(diary, memberChecklist, checklist);
+    }
+
+    public List<DiaryChecklist> getDiaryChecklistByDiaryIds(List<Long> diaryIds) {
+        return this.diaryChecklistEntityService.getDiaryChecklistByDiaryIds(diaryIds);
     }
 }

--- a/src/main/java/com/dnd/bbok/domain/checklist/service/DiaryChecklistService.java
+++ b/src/main/java/com/dnd/bbok/domain/checklist/service/DiaryChecklistService.java
@@ -4,12 +4,13 @@ import com.dnd.bbok.domain.checklist.entity.MemberChecklist;
 import com.dnd.bbok.domain.diary.dto.request.ChecklistDto;
 import com.dnd.bbok.domain.diary.entity.Diary;
 import com.dnd.bbok.global.exception.BusinessException;
-import com.dnd.bbok.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.dnd.bbok.global.exception.ErrorCode.INVALID_MEMBER_CHECKLIST_ID;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +23,7 @@ public class DiaryChecklistService {
         List<MemberChecklist> memberChecklist = memberChecklistEntityService.getMemberChecklistInIds(checklist.stream().map(ChecklistDto::getId).collect(Collectors.toList()));
 
         if (memberChecklist.size() != NEED_CHECKLIST_COUNT) {
-           throw new BusinessException(ErrorCode.INVALID_MEMBER_CHECKLIST_ID);
+           throw new BusinessException(INVALID_MEMBER_CHECKLIST_ID);
         }
 
         diaryChecklistEntityService.createDiaryChecklist(diary, memberChecklist, checklist);

--- a/src/main/java/com/dnd/bbok/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/controller/DiaryController.java
@@ -1,14 +1,17 @@
 package com.dnd.bbok.domain.diary.controller;
 
+import com.dnd.bbok.domain.checklist.entity.DiaryChecklist;
 import com.dnd.bbok.domain.checklist.service.DiaryChecklistService;
 import com.dnd.bbok.domain.diary.dto.request.DiaryRequestDto;
+import com.dnd.bbok.domain.diary.dto.response.DiariesDto;
 import com.dnd.bbok.domain.diary.dto.response.DiaryCreateDto;
+import com.dnd.bbok.domain.diary.dto.response.DiaryDto;
 import com.dnd.bbok.domain.diary.dto.response.DiarySayingDto;
 import com.dnd.bbok.domain.diary.entity.Diary;
 import com.dnd.bbok.domain.diary.service.DiaryService;
 import com.dnd.bbok.domain.jwt.dto.SessionUser;
 import com.dnd.bbok.domain.saying.service.SayingService;
-import com.dnd.bbok.domain.tag.service.DiaryTagEntityService;
+import com.dnd.bbok.domain.tag.entity.DiaryTag;
 import com.dnd.bbok.domain.diary.service.FriendTempService;
 import com.dnd.bbok.domain.tag.service.TagService;
 import com.dnd.bbok.domain.friend.entity.Friend;
@@ -26,7 +29,9 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -37,7 +42,6 @@ public class DiaryController {
     private final FriendTempService friendService;
     private final TagService tagService;
     private final DiaryService diaryService;
-    private final DiaryTagEntityService diaryTagEntityService;
     private final DiaryChecklistService diaryChecklistService;
     private final SayingService sayingService;
 
@@ -56,7 +60,7 @@ public class DiaryController {
         // 2. 일기 생성
         Diary diary = diaryService.createDiary(friend, diaryRequestDto);
         // 3. 일기 태그 엔티티 생성
-        diaryTagEntityService.createDiaryTag(diary, friendTags);
+        tagService.createDiaryTag(diary, friendTags);
         // 3. 체크리스트 생성
         diaryChecklistService.createDiaryChecklist(diary, diaryRequestDto.getChecklist());
         // 4. 점수 계산 및 업데이트
@@ -66,5 +70,27 @@ public class DiaryController {
 
         DiaryCreateDto createDiaryDto = new DiaryCreateDto(diarySayingDto, score);
         return new ResponseEntity<>(DataResponse.of(HttpStatus.OK , "일기 생성 성공", createDiaryDto), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "일기 목록 조회")
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("{id}/diary")
+    public ResponseEntity<DataResponse<DiariesDto>> getDiaries(
+            @Parameter(name = "id", in = ParameterIn.PATH, description = "친구 id") @PathVariable("id") Long id,
+            @Parameter(name = "offset", in = ParameterIn.QUERY, description = "목록 오프셋") @RequestParam(value = "offset", required = false) Integer offset,
+            @Parameter(name = "order", in = ParameterIn.QUERY, description = "시간 정렬 기준") @RequestParam(value = "order", required = false) String order,
+            @Parameter(name = "q", in = ParameterIn.QUERY, description = "검색어") @RequestParam(value = "q", required = false) String keyword,
+            @Parameter(name = "tag", in = ParameterIn.QUERY, description = "태그") @RequestParam(value = "tag", required = false) String tag
+    ) {
+        // TODO 남의 일기를 조회 요청한 경우 에러처러??
+
+        List<Diary> diaries = this.diaryService.getDiariesByFriendId(id);
+        List<Long> diaryIds = diaries.stream().map(Diary::getId).collect(Collectors.toList());
+        List<DiaryTag> diaryTags = this.tagService.getDiariesTags(diaryIds);
+        List<DiaryChecklist> diaryChecklists = this.diaryChecklistService.getDiaryChecklistByDiaryIds(diaryIds);
+        ArrayList<DiaryDto> diaryDtos = new ArrayList<>();
+        diaries.forEach(diary -> diaryDtos.add(new DiaryDto(diary, diaryTags, diaryChecklists)));
+        DiariesDto list = new DiariesDto(diaryDtos);
+        return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "일기 목록 조회 성공", list), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/controller/DiaryController.java
@@ -3,10 +3,7 @@ package com.dnd.bbok.domain.diary.controller;
 import com.dnd.bbok.domain.checklist.entity.DiaryChecklist;
 import com.dnd.bbok.domain.checklist.service.DiaryChecklistService;
 import com.dnd.bbok.domain.diary.dto.request.DiaryRequestDto;
-import com.dnd.bbok.domain.diary.dto.response.DiariesDto;
-import com.dnd.bbok.domain.diary.dto.response.DiaryCreateDto;
-import com.dnd.bbok.domain.diary.dto.response.DiaryDto;
-import com.dnd.bbok.domain.diary.dto.response.DiarySayingDto;
+import com.dnd.bbok.domain.diary.dto.response.*;
 import com.dnd.bbok.domain.diary.entity.Diary;
 import com.dnd.bbok.domain.diary.service.DiaryService;
 import com.dnd.bbok.domain.jwt.dto.SessionUser;
@@ -92,5 +89,16 @@ public class DiaryController {
         diaries.forEach(diary -> diaryDtos.add(new DiaryDto(diary, diaryTags, diaryChecklists)));
         DiariesDto list = new DiariesDto(diaryDtos);
         return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "일기 목록 조회 성공", list), HttpStatus.OK);
+    }
+
+    @ApiOperation("태그 목록 조회")
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("{id}/diary/tag")
+    public ResponseEntity<DataResponse<DiaryTagDto>> getTags(
+            @Parameter(name = "id", in = ParameterIn.PATH, description = "친구 id") @PathVariable("id") Long id
+    ) {
+        List<FriendTag> tags = this.tagService.getFriendTagsByFriendId(id);
+        DiaryTagDto diaryTagDto = new DiaryTagDto(tags);
+        return new ResponseEntity<>(DataResponse.of(HttpStatus.OK , "태그 목록 조회 성공", diaryTagDto), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/dto/response/DiaryChecklistDto.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/dto/response/DiaryChecklistDto.java
@@ -2,7 +2,6 @@ package com.dnd.bbok.domain.diary.dto.response;
 
 import lombok.Getter;
 
-import java.util.Random;
 
 @Getter
 public class DiaryChecklistDto {
@@ -10,8 +9,8 @@ public class DiaryChecklistDto {
     private final String criteria;
     private final Boolean isChecked;
 
-    public DiaryChecklistDto(String criteria, boolean isChecked) {
-        this.id = Math.abs(new Random().nextLong() % 21);
+    public DiaryChecklistDto(Long id, String criteria, boolean isChecked) {
+        this.id = id;
         this.criteria = criteria;
         this.isChecked = isChecked;
     }

--- a/src/main/java/com/dnd/bbok/domain/diary/dto/response/DiaryDto.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/dto/response/DiaryDto.java
@@ -1,12 +1,17 @@
 package com.dnd.bbok.domain.diary.dto.response;
 
+import com.dnd.bbok.domain.checklist.entity.DiaryChecklist;
+import com.dnd.bbok.domain.diary.entity.Diary;
 import com.dnd.bbok.domain.diary.entity.Emoji;
+import com.dnd.bbok.domain.tag.entity.DiaryTag;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Getter
 public class DiaryDto {
@@ -47,21 +52,40 @@ public class DiaryDto {
         tags.add("거짓말");
         tags.add("가스라이팅");
         this.goodChecklist = new ArrayList<>();
-        goodChecklist.add(new DiaryChecklistDto("이야기를 잘 듣고 공감해주는 친구", true));
-        goodChecklist.add(new DiaryChecklistDto("존중하고 배려하는 마음을 가진 친구 ", true));
-        goodChecklist.add(new DiaryChecklistDto("관심사가 비슷한 친구", false));
-        goodChecklist.add(new DiaryChecklistDto("신뢰할 수 있는 친구", false));
-        goodChecklist.add(new DiaryChecklistDto("성격이 잘 맞는 친구", true));
+        goodChecklist.add(new DiaryChecklistDto(1L, "이야기를 잘 듣고 공감해주는 친구", true));
+        goodChecklist.add(new DiaryChecklistDto(1L, "존중하고 배려하는 마음을 가진 친구 ", true));
+        goodChecklist.add(new DiaryChecklistDto(1L, "관심사가 비슷한 친구", false));
+        goodChecklist.add(new DiaryChecklistDto(1L, "신뢰할 수 있는 친구", false));
+        goodChecklist.add(new DiaryChecklistDto(1L, "성격이 잘 맞는 친구", true));
 
         this.badChecklist = new ArrayList<>();
-        badChecklist.add(new DiaryChecklistDto("나를 배려하지 않는 친구", false));
-        badChecklist.add(new DiaryChecklistDto("신뢰를 잃는 행동을 하는 친구", true));
-        badChecklist.add(new DiaryChecklistDto("나의 자존감을 낮추는 친구", false));
-        badChecklist.add(new DiaryChecklistDto("유머코드가 맞지 않는 친구", true));
-        badChecklist.add(new DiaryChecklistDto("나에게 너무 많이 의존하는 친구", false));
+        badChecklist.add(new DiaryChecklistDto(1L, "나를 배려하지 않는 친구", false));
+        badChecklist.add(new DiaryChecklistDto(1L, "신뢰를 잃는 행동을 하는 친구", true));
+        badChecklist.add(new DiaryChecklistDto(1L, "나의 자존감을 낮추는 친구", false));
+        badChecklist.add(new DiaryChecklistDto(1L, "유머코드가 맞지 않는 친구", true));
+        badChecklist.add(new DiaryChecklistDto(1L, "나에게 너무 많이 의존하는 친구", false));
 
         this.sticker = "[{sticker: KK, url: \"https://i.ibb.co/zbHrDVm/angry.png\"}]";
     }
 
+    public DiaryDto(Diary diary, List<DiaryTag> tags, List<DiaryChecklist> checklist) {
 
+        this.id = diary.getId();
+        this.emoji = diary.getEmoji();
+        this.date = diary.getDiaryDate();
+        this.content = diary.getContents();
+        // Diary Tag 중에서 현재 Diary 의 id 를 가지는 태그들을 찾고, 그 태그들의 이름을 Friend Tag 에서 가져옴
+        this.tags = tags.stream().filter(tag -> Objects.equals(tag.getDiary().getId(), diary.getId())).map(tag -> tag.getFriendTag().getName()).collect(Collectors.toList());
+
+        this.goodChecklist = new ArrayList<>();
+        this.badChecklist = new ArrayList<>();
+        // Diary Checklist 중에서 현재 Diary 의 id를 가지는 체크리스트들을 찾고, 그 태그들로 각 checklist 생성
+        List<DiaryChecklist> targetChecklist = checklist.stream().filter(ele -> Objects.equals(ele.getDiary().getId(), diary.getId())).collect(Collectors.toList());
+        targetChecklist.stream().filter(ele -> ele.getMemberChecklist().isGood()).forEach(ele -> this.goodChecklist.add(new DiaryChecklistDto(ele.getId(), ele.getMemberChecklist().getCriteria(), ele.isChecked())));
+        targetChecklist.stream().filter(ele -> !ele.getMemberChecklist().isGood()).forEach(ele -> this.badChecklist.add(new DiaryChecklistDto(ele.getId(), ele.getMemberChecklist().getCriteria(), ele.isChecked())));
+
+        // TODO 수정필요
+        this.sticker = "[{sticker: KK, url: \"https://i.ibb.co/zbHrDVm/angry.png\"}]";
+        this.emojiUrl = "https://i.ibb.co/zbHrDVm/angry.png";
+    }
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/dto/response/DiaryTagDto.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/dto/response/DiaryTagDto.java
@@ -14,8 +14,6 @@ public class DiaryTagDto {
 
     public DiaryTagDto(List<FriendTag> tags) {
         this.tags = new ArrayList<>();
-        tags.forEach(tag -> {
-            this.tags.add(new TagDto(tag.getId(), tag.getName()));
-        });
+        tags.forEach(tag -> this.tags.add(new TagDto(tag.getId(), tag.getName())));
     }
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/dto/response/DiaryTagDto.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/dto/response/DiaryTagDto.java
@@ -1,17 +1,21 @@
 package com.dnd.bbok.domain.diary.dto.response;
 
+import com.dnd.bbok.domain.tag.entity.FriendTag;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 public class DiaryTagDto {
     @ApiModelProperty(value = "태그 목록")
     private final ArrayList<TagDto> tags;
 
-    public DiaryTagDto() {
+    public DiaryTagDto(List<FriendTag> tags) {
         this.tags = new ArrayList<>();
-        this.tags.add(new TagDto());
+        tags.forEach(tag -> {
+            this.tags.add(new TagDto(tag.getId(), tag.getName()));
+        });
     }
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/dto/response/TagDto.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/dto/response/TagDto.java
@@ -11,8 +11,9 @@ public class TagDto {
     @ApiModelProperty(value = "태그 이름")
     private final String tag;
 
-    public TagDto() {
-        this.id = 1L;
-        this.tag = "가스라이팅";
+
+    public TagDto(long id, String tag) {
+        this.id = id;
+        this.tag = tag;
     }
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/repository/DiaryRepository.java
@@ -3,5 +3,8 @@ package com.dnd.bbok.domain.diary.repository;
 import com.dnd.bbok.domain.diary.entity.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    List<Diary> findAllByFriendId(Long friendId);
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/service/DiaryEntityService.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/service/DiaryEntityService.java
@@ -7,6 +7,8 @@ import com.dnd.bbok.domain.friend.entity.Friend;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 /**
  * Diary Entity 관련한 DB 작업을 수행하는 서비스
  */
@@ -23,5 +25,9 @@ public class DiaryEntityService {
                 .diaryDate(diaryRequestDto.getDate())
                 .build();
         return this.diaryRepository.save(diary);
+    }
+
+    public List<Diary> getDiariesByFriendId(Long friendId) {
+        return this.diaryRepository.findAllByFriendId(friendId);
     }
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/service/DiaryService.java
@@ -42,4 +42,8 @@ public class DiaryService {
         return friendTempService.updateFriendScore(friend, score).getFriendScore();
     }
 
+    // TODO Paging 기능 구현
+    public List<Diary> getDiariesByFriendId(Long friendId) {
+        return this.diaryEntityService.getDiariesByFriendId(friendId);
+    }
 }

--- a/src/main/java/com/dnd/bbok/domain/saying/service/SayingEntityService.java
+++ b/src/main/java/com/dnd/bbok/domain/saying/service/SayingEntityService.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Random;
 
 /**
  * Saying Entity 와 관련된 DB 작업을 수행하는 서비스
@@ -15,13 +14,8 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class SayingEntityService {
     private final SayingRepository sayingRepository;
-
-    public Saying getRandomSaying() {
-        List<Saying> sayings = this.sayingRepository.findAll();
-
-        Random random = new Random();
-        int index = random.nextInt(sayings.size());
-
-        return sayings.get(index);
+    public List<Saying> getAllSaying() {
+        return this.sayingRepository.findAll();
     }
+
 }

--- a/src/main/java/com/dnd/bbok/domain/saying/service/SayingService.java
+++ b/src/main/java/com/dnd/bbok/domain/saying/service/SayingService.java
@@ -5,6 +5,8 @@ import com.dnd.bbok.domain.saying.entity.Saying;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 
 /**
@@ -17,7 +19,11 @@ public class SayingService {
     private final SayingEntityService sayingEntityService;
 
     public DiarySayingDto getRandomSaying(UUID memberId) {
-        Saying saying = sayingEntityService.getRandomSaying();
+        List<Saying> sayings = sayingEntityService.getAllSaying();
+        Random random = new Random();
+        int index = random.nextInt(sayings.size());
+        Saying saying = sayings.get(index);
+        
         boolean isMarked = bookmarkEntityService.isMarked(memberId, saying.getId());
 
         return DiarySayingDto.builder()

--- a/src/main/java/com/dnd/bbok/domain/tag/entity/DiaryTag.java
+++ b/src/main/java/com/dnd/bbok/domain/tag/entity/DiaryTag.java
@@ -5,6 +5,7 @@ import static javax.persistence.GenerationType.*;
 
 import com.dnd.bbok.domain.diary.entity.Diary;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
@@ -17,6 +18,7 @@ import javax.persistence.ManyToOne;
  * 다이어리가 가지고 있는 태그 정보
  */
 @Entity
+@Getter
 @NoArgsConstructor
 public class DiaryTag {
 

--- a/src/main/java/com/dnd/bbok/domain/tag/repository/DiaryTagRepository.java
+++ b/src/main/java/com/dnd/bbok/domain/tag/repository/DiaryTagRepository.java
@@ -2,8 +2,15 @@ package com.dnd.bbok.domain.tag.repository;
 
 import com.dnd.bbok.domain.tag.entity.DiaryTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryTagRepository extends JpaRepository<DiaryTag, Long> {
+    @Query("SELECT dt FROM DiaryTag dt LEFT JOIN FETCH dt.friendTag WHERE dt.diary.id = :diaryId")
+    Optional<DiaryTag> findByDiaryId(Long diaryId);
+
+    @Query("SELECT dt FROM DiaryTag dt LEFT JOIN FETCH dt.friendTag LEFT JOIN FETCH dt.diary WHERE dt.diary.id IN :diaryIds")
+    List<DiaryTag> findByDiaryIds(List<Long> diaryIds);
 }

--- a/src/main/java/com/dnd/bbok/domain/tag/service/DiaryTagEntityService.java
+++ b/src/main/java/com/dnd/bbok/domain/tag/service/DiaryTagEntityService.java
@@ -25,4 +25,8 @@ public class DiaryTagEntityService {
                     .build())
         );
     }
+
+    public List<DiaryTag> getDiariesTags(List<Long> diaryIds) {
+        return this.diaryTagRepository.findByDiaryIds(diaryIds);
+    }
 }

--- a/src/main/java/com/dnd/bbok/domain/tag/service/TagService.java
+++ b/src/main/java/com/dnd/bbok/domain/tag/service/TagService.java
@@ -2,13 +2,18 @@ package com.dnd.bbok.domain.tag.service;
 
 import com.dnd.bbok.domain.friend.entity.Friend;
 import com.dnd.bbok.domain.tag.entity.FriendTag;
+import com.dnd.bbok.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.dnd.bbok.global.exception.ErrorCode.EXCEED_MAX_TAG_COUNT;
 
 /**
  * 태그 생성 및 조회 logic 을 실행하는 서비스
@@ -16,6 +21,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class TagService {
+    private static final int MAX_TAG_COUNT = 5;
     private final FriendTagEntityService friendTagEntityService;
 
 
@@ -24,14 +30,21 @@ public class TagService {
      * @param friend 친구 엔티티
      * @param tags 이번 일기에 사용한 태그 목록
      */
+    @Transactional(rollbackOn = BusinessException.class)
     public List<FriendTag> getFriendTags(Friend friend, List<String> tags) {
         List<FriendTag> targetFriendTags = new ArrayList<>();
         List<FriendTag> friendTags = friendTagEntityService.getFriendTags(friend.getId());
+        AtomicInteger tagCount = new AtomicInteger(friendTags.size());
         tags.forEach(tag -> {
             Optional<FriendTag> targetTag = friendTags.stream().filter(ele -> Objects.equals(ele.getFriend().getId(), friend.getId())).findFirst();
             if (targetTag.isPresent()) {
                 targetFriendTags.add(targetTag.get());
             } else {
+                if (tagCount.get() == MAX_TAG_COUNT) {
+                    // 이번에 추가해서 태그 갯수가 5개 이상 된다면 에러
+                    throw new BusinessException(EXCEED_MAX_TAG_COUNT);
+                }
+                tagCount.addAndGet(1);
                 targetFriendTags.add(friendTagEntityService.createTag(tag, friend));
             }
         });

--- a/src/main/java/com/dnd/bbok/domain/tag/service/TagService.java
+++ b/src/main/java/com/dnd/bbok/domain/tag/service/TagService.java
@@ -60,4 +60,8 @@ public class TagService {
     public List<DiaryTag> getDiariesTags(List<Long> diaryIds) {
         return this.diaryTagEntityService.getDiariesTags(diaryIds);
     }
+
+    public List<FriendTag> getFriendTagsByFriendId(Long friendId) {
+        return this.friendTagEntityService.getFriendTags(friendId);
+    }
 }

--- a/src/main/java/com/dnd/bbok/domain/tag/service/TagService.java
+++ b/src/main/java/com/dnd/bbok/domain/tag/service/TagService.java
@@ -1,6 +1,8 @@
 package com.dnd.bbok.domain.tag.service;
 
+import com.dnd.bbok.domain.diary.entity.Diary;
 import com.dnd.bbok.domain.friend.entity.Friend;
+import com.dnd.bbok.domain.tag.entity.DiaryTag;
 import com.dnd.bbok.domain.tag.entity.FriendTag;
 import com.dnd.bbok.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +25,7 @@ import static com.dnd.bbok.global.exception.ErrorCode.EXCEED_MAX_TAG_COUNT;
 public class TagService {
     private static final int MAX_TAG_COUNT = 5;
     private final FriendTagEntityService friendTagEntityService;
-
+    private final DiaryTagEntityService diaryTagEntityService;
 
     /**
      * 이번 일기 작성에 사용된 tag 들의 id 목록 반환
@@ -49,5 +51,13 @@ public class TagService {
             }
         });
         return targetFriendTags;
+    }
+
+    public void createDiaryTag(Diary diary, List<FriendTag> friendTags) {
+        this.diaryTagEntityService.createDiaryTag(diary, friendTags);
+    }
+
+    public List<DiaryTag> getDiariesTags(List<Long> diaryIds) {
+        return this.diaryTagEntityService.getDiariesTags(diaryIds);
     }
 }

--- a/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
 
   // Diary
   INVALID_MEMBER_CHECKLIST_ID(HttpStatus.BAD_REQUEST, "D001","Member Checklist Id가 올바르지 않습니다."),
+  EXCEED_MAX_TAG_COUNT(HttpStatus.BAD_REQUEST, "D002", "친구 당 최대 태그 갯수를 벗어났습니다."),
+
   // JWT
   REFRESH_JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "J003", "만료된 리프레시 토큰입니다.");
 

--- a/src/main/java/com/dnd/bbok/mock/DiaryMockController.java
+++ b/src/main/java/com/dnd/bbok/mock/DiaryMockController.java
@@ -23,12 +23,6 @@ public class DiaryMockController {
         return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "일기 조회 성공", diary), HttpStatus.OK);
     }
 
-    @ApiOperation("태그 목록 조회")
-    @GetMapping("diary/tag")
-    public ResponseEntity<DataResponse<DiaryTagDto>> getTags() {
-        return new ResponseEntity<>(DataResponse.of(HttpStatus.OK , "태그 목록 조회 성공", new DiaryTagDto()), HttpStatus.OK);
-    }
-
     @ApiOperation("스티커 목록 조회")
     @GetMapping("diary/sticker")
     public ResponseEntity<DataResponse<DiaryStickerDto>> getStickers() {

--- a/src/main/java/com/dnd/bbok/mock/DiaryMockController.java
+++ b/src/main/java/com/dnd/bbok/mock/DiaryMockController.java
@@ -1,6 +1,5 @@
 package com.dnd.bbok.mock;
 
-import com.dnd.bbok.domain.diary.dto.request.DiaryRequestDto;
 import com.dnd.bbok.domain.diary.dto.response.*;
 import com.dnd.bbok.global.response.DataResponse;
 import com.dnd.bbok.global.response.MessageResponse;
@@ -12,8 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
-
 @RestController
 @RequestMapping("api/v1/friend")
 @Api(tags = "Mock 일기 관련 컨트롤러")
@@ -24,22 +21,6 @@ public class DiaryMockController {
     public ResponseEntity<DataResponse<DiaryDto>> getDiary(@PathVariable("id") Long id) {
         DiaryDto diary = new DiaryDto(id);
         return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "일기 조회 성공", diary), HttpStatus.OK);
-    }
-
-    @ApiOperation(value = "일기 목록 조회")
-    @GetMapping("{id}/diary")
-    public ResponseEntity<DataResponse<DiariesDto>> getDiaries(
-            @Parameter(name = "id", in = ParameterIn.PATH, description = "친구 id") @PathVariable("id") Long id,
-            @Parameter(name = "offset", in = ParameterIn.QUERY, description = "목록 오프셋") @RequestParam(value = "offset", required = false) Integer offset,
-            @Parameter(name = "order", in = ParameterIn.QUERY, description = "시간 정렬 기준") @RequestParam(value = "order", required = false) String order,
-            @Parameter(name = "q", in = ParameterIn.QUERY, description = "검색어") @RequestParam(value = "q", required = false) String keyword,
-            @Parameter(name = "tag", in = ParameterIn.QUERY, description = "태그") @RequestParam(value = "tag", required = false) String tag
-    ) {
-        DiaryDto diary = new DiaryDto(1L);
-        ArrayList<DiaryDto> diaries = new ArrayList<>();
-        diaries.add(diary);
-        DiariesDto list = new DiariesDto(diaries);
-        return new ResponseEntity<>(DataResponse.of(HttpStatus.OK, "일기 목록 조회 성공", list), HttpStatus.OK);
     }
 
     @ApiOperation("태그 목록 조회")


### PR DESCRIPTION
## What is this PR? 🔍
- 일기 조회 기능을 구현하였습니다.
- 친구별 태그 목록 조회 기능을 구현하였습니다.
- 어제 새벽 진행한 코드리뷰의 피드백 내용을 적용하였습니다.

## Key Changes 📝
- [x] 일기 조회 api 및 필요한 db logic 구현
- [x] Code Review Feedback 적용
- [x] 태그 목록 조회에 필요한 logic, api 구현

## Test Checklist ✅
- 없습니다.

## To Reviewers
- JPQL Fetch Join을 처음 사용해봤는데 조금 헷갈리네요..! 이 부분 위주로 봐주시면 감사하겠습니다.
- Meber - Friend 간 정합성 검사는 SessionUser 업데이트 이후 추가하겠습니다. (그래서 23번 이슈 아직 안닫았어요!!)