### PR TITLE
feat: 등록한 친구 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/dnd/bbok/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/dnd/bbok/domain/common/BaseTimeEntity.java
@@ -1,6 +1,6 @@
 package com.dnd.bbok.domain.common;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
@@ -16,10 +16,10 @@ public abstract class BaseTimeEntity {
 
   @CreatedDate
   @Column(name = "CREATED_AT")
-  private LocalDateTime createdAt;
+  private LocalDate createdAt;
 
   @LastModifiedDate
   @Column(name = "MODIFIED_AT")
-  private LocalDateTime modifiedAt;
+  private LocalDate modifiedAt;
 
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/repository/DiaryRepository.java
@@ -4,7 +4,12 @@ import com.dnd.bbok.domain.diary.entity.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<Diary> findAllByFriendId(Long friendId);
+
+    @Query("select count(*) from Diary d where d.friend.id = :friendId")
+    int countDiaries(@Param("friendId") Long friendId);
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/service/DiaryEntityService.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/service/DiaryEntityService.java
@@ -30,4 +30,8 @@ public class DiaryEntityService {
     public List<Diary> getDiariesByFriendId(Long friendId) {
         return this.diaryRepository.findAllByFriendId(friendId);
     }
+
+    public int countDiariesByFriendId(Long friendId) {
+        return this.diaryRepository.countDiaries(friendId);
+    }
 }

--- a/src/main/java/com/dnd/bbok/domain/diary/service/FriendTempService.java
+++ b/src/main/java/com/dnd/bbok/domain/diary/service/FriendTempService.java
@@ -18,7 +18,7 @@ public class FriendTempService {
     }
 
     public Friend updateFriendScore(Friend friend, Long score) {
-        friend.setFriendScore(score);
+        friend.changeFriendScore(score);
         return this.friendRepository.save(friend);
     }
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/controller/FriendController.java
@@ -2,6 +2,8 @@ package com.dnd.bbok.domain.friend.controller;
 
 import com.dnd.bbok.domain.friend.dto.request.FriendRequestDto;
 import com.dnd.bbok.domain.friend.dto.response.BbokCharactersDto;
+import com.dnd.bbok.domain.friend.dto.response.FriendsDto;
+import com.dnd.bbok.domain.friend.service.DiaryFriendUseCaseService;
 import com.dnd.bbok.domain.friend.service.MemberFriendUseCaseService;
 import com.dnd.bbok.domain.friend.service.IconService;
 import com.dnd.bbok.domain.jwt.dto.SessionUser;
@@ -28,6 +30,7 @@ public class FriendController {
 
   private final IconService iconService;
   private final MemberFriendUseCaseService memberFriendUseCaseService;
+  private final DiaryFriendUseCaseService diaryFriendUseCaseService;
 
   @ApiOperation(value = "캐릭터 정보 제공")
   @GetMapping("/character")
@@ -49,4 +52,14 @@ public class FriendController {
         MessageResponse.of(HttpStatus.CREATED, "친구 등록 성공"), HttpStatus.CREATED);
   }
 
+  @ApiOperation(value = "친구 목록 조회")
+  @GetMapping("/friend")
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<DataResponse<FriendsDto>> getFriends(
+      @AuthenticationPrincipal SessionUser sessionUser
+  ) {
+    FriendsDto friends = diaryFriendUseCaseService.getFriends(sessionUser.getUuid());
+    return new ResponseEntity<>(
+        DataResponse.of(HttpStatus.OK, "친구 목록 조회 성공", friends), HttpStatus.OK);
+  }
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/dto/response/FriendDto.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/dto/response/FriendDto.java
@@ -1,6 +1,8 @@
 package com.dnd.bbok.domain.friend.dto.response;
 
+import com.dnd.bbok.domain.friend.entity.Friend;
 import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDate;
 import lombok.Getter;
 
 /**
@@ -12,8 +14,8 @@ public class FriendDto {
   @ApiModelProperty(value = "친구 고유 ID")
   private final Long id;
 
-  @ApiModelProperty(value = "친구 생성 날짜 카운팅")
-  private final int countingDay;
+  @ApiModelProperty(value = "친구 생성 날짜")
+  private final LocalDate startedAt;
 
   @ApiModelProperty(value = "친구 캐릭터 아이콘 url")
   private final String characterUrl;
@@ -28,19 +30,16 @@ public class FriendDto {
   private final Long score;
 
   @ApiModelProperty(value = "친구 활성화 상태")
-  private final boolean status;
+  private final boolean isActive;
 
-  /**
-   * mock 제공을 위한 기본생성자
-   */
-  public FriendDto() {
-    this.id = 1L;
-    this.countingDay = 23;
-    this.characterUrl = "https://i.ibb.co/ZgfdtSY/hedgehog.png";
-    this.name = "김도리";
-    this.countingDiary = 6;
-    this.score = 58L;
-    this.status = true;
+  public FriendDto(Friend friend, String iconUrl, int diaryCount) {
+    this.id = friend.getId();
+    this.startedAt = friend.getCreatedAt();
+    this.characterUrl = iconUrl;
+    this.name = friend.getName();
+    this.countingDiary = diaryCount;
+    this.score = friend.getFriendScore();
+    this.isActive = friend.isActive();
   }
 
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/dto/response/FriendsDto.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/dto/response/FriendsDto.java
@@ -1,7 +1,6 @@
 package com.dnd.bbok.domain.friend.dto.response;
 
 import io.swagger.annotations.ApiModelProperty;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 
@@ -12,16 +11,10 @@ import lombok.Getter;
 public class FriendsDto {
 
   @ApiModelProperty(value = "친구 목록")
-  private final List<FriendDto> friends = new ArrayList<>();
+  private final List<FriendDto> friends;
 
-  /**
-   * mock 제공을 위한 기본생성자
-   */
-  public FriendsDto() {
-    FriendDto friend = new FriendDto();
-    FriendDto friend2 = new FriendDto();
-    friends.add(friend);
-    friends.add(friend2);
+  public FriendsDto(List<FriendDto> friends) {
+    this.friends = friends;
   }
 
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/entity/Friend.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/entity/Friend.java
@@ -44,7 +44,7 @@ public class Friend extends BaseTimeEntity {
   @JoinColumn(name = "member_id")
   private Member member;
 
-  public void setFriendScore(Long friendScore) {
+  public void changeFriendScore(Long friendScore) {
     this.friendScore = friendScore;
   }
 

--- a/src/main/java/com/dnd/bbok/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/repository/FriendRepository.java
@@ -10,5 +10,10 @@ import org.springframework.data.repository.query.Param;
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
   @Query("select f from Friend f where f.member.id = :memberId")
-  List<Friend> findOtherFriend(@Param("memberId") UUID memberId);
+  List<Friend> findAllFriends(@Param("memberId") UUID memberId);
+
+  //TODO: 승훈님이 요청하신 친구 Id로 친구를 조회하는 메서드 구현
+  @Query("select f from Friend f where f.id = :friendId")
+  Friend findFriendById(@Param("friendId") Long friendId);
+
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/repository/FriendRepository.java
@@ -2,6 +2,7 @@ package com.dnd.bbok.domain.friend.repository;
 
 import com.dnd.bbok.domain.friend.entity.Friend;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +15,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
   //TODO: 승훈님이 요청하신 친구 Id로 친구를 조회하는 메서드 구현
   @Query("select f from Friend f where f.id = :friendId")
-  Friend findFriendById(@Param("friendId") Long friendId);
+  Optional<Friend> findFriendById(@Param("friendId") Long friendId);
 
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/service/DiaryFriendUseCaseService.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/service/DiaryFriendUseCaseService.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Friend, Diary 관련 서비스
@@ -36,4 +37,11 @@ public class DiaryFriendUseCaseService {
     return new FriendsDto(friends);
   }
 
+
+  //TODO: 점수 받으면 friend에 업데이트하는 서비스(friendId, score)
+  @Transactional
+  public void updateScore(Long friendId, Long score) {
+    Friend friend = friendService.getFriend(friendId);
+    friend.changeFriendScore(score);
+  }
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/service/DiaryFriendUseCaseService.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/service/DiaryFriendUseCaseService.java
@@ -1,0 +1,39 @@
+package com.dnd.bbok.domain.friend.service;
+
+import com.dnd.bbok.domain.diary.service.DiaryEntityService;
+import com.dnd.bbok.domain.friend.dto.response.FriendDto;
+import com.dnd.bbok.domain.friend.dto.response.FriendsDto;
+import com.dnd.bbok.domain.friend.entity.Friend;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Friend, Diary 관련 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class DiaryFriendUseCaseService {
+
+  private final FriendService friendService;
+  private final IconService iconService;
+  private final DiaryEntityService diaryEntityService;
+
+  public FriendsDto getFriends(UUID memberId) {
+
+    List<Friend> friendsOfMember = friendService.findFriendsOfMember(memberId);
+
+    List<FriendDto> friends = friendsOfMember.stream()
+        .map(each -> {
+          String iconUrl = iconService.getIconUrl(each.getBbok());
+          int countDiary = diaryEntityService.countDiariesByFriendId(each.getId());
+          return new FriendDto(each, iconUrl, countDiary);
+        })
+        .collect(Collectors.toList());
+
+    return new FriendsDto(friends);
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/domain/friend/service/FriendService.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/service/FriendService.java
@@ -1,5 +1,6 @@
 package com.dnd.bbok.domain.friend.service;
 
+import static com.dnd.bbok.global.exception.ErrorCode.FRIEND_NOT_FOUND;
 import static com.dnd.bbok.global.exception.ErrorCode.OTHER_FRIEND_ALREADY_ACTIVE;
 
 import com.dnd.bbok.domain.friend.entity.Friend;
@@ -7,6 +8,7 @@ import com.dnd.bbok.domain.friend.repository.FriendRepository;
 import com.dnd.bbok.domain.member.entity.Member;
 import com.dnd.bbok.global.exception.BusinessException;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,11 +29,22 @@ public class FriendService {
 
   @Transactional(readOnly = true)
   public void checkOtherActiveFriend(Member member) {
-    List<Friend> otherFriends = friendRepository.findOtherFriend(member.getId());
+    List<Friend> otherFriends = friendRepository.findAllFriends(member.getId());
     for(Friend each : otherFriends) {
       if(each.isActive()) {
         throw new BusinessException(OTHER_FRIEND_ALREADY_ACTIVE);
       }
     }
   }
+
+  @Transactional(readOnly = true)
+  public List<Friend> findFriendsOfMember(UUID memberId) {
+    return friendRepository.findAllFriends(memberId);
+  }
+
+  public Friend getFriend(Long friendId) {
+    return friendRepository.findFriendById(friendId)
+        .orElseThrow(() -> new BusinessException(FRIEND_NOT_FOUND));
+  }
+
 }

--- a/src/main/java/com/dnd/bbok/domain/friend/service/IconService.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/service/IconService.java
@@ -22,6 +22,13 @@ public class IconService {
 
   private final S3Downloader s3Downloader;
 
+  /**
+   * 하나의 Icon url만 반환하는 로직
+   */
+  public String getIconUrl(BbokCharacter bbok) {
+    return s3Downloader.getIconUrl(bbok.getIconFile());
+  }
+
   public BbokCharactersDto getCharacterIcon() {
     List<BbokCharacterDto> list = new ArrayList<>();
     //1. 모든 캐릭터를 가져온다.

--- a/src/main/java/com/dnd/bbok/domain/friend/service/MemberFriendUseCaseService.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/service/MemberFriendUseCaseService.java
@@ -19,7 +19,7 @@ public class MemberFriendUseCaseService {
 
   public void createFriendCharacter(UUID memberId, FriendRequestDto requestFriend) {
     Member member = memberService.getMemberById(memberId);
-    //2. member가 활성화된 다른 친구를 가지고 있는지 체크해야 한다.
+    //member가 활성화된 다른 친구를 가지고 있는지 체크
     friendService.checkOtherActiveFriend(member);
     friendService.saveFriend(requestFriend.toEntity(member));
   }

--- a/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
+++ b/src/main/java/com/dnd/bbok/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
   // Friend
   CHARACTER_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "해당 이름을 가진 캐릭터를 찾을 수 없습니다."),
   OTHER_FRIEND_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "F002", "동시에 2명 이상의 친구를 생성할 수 없습니다."),
+  FRIEND_NOT_FOUND(HttpStatus.BAD_REQUEST, "F003", "해당 아이디를 가진 친구를 찾을 수 없습니다."),
 
   // Diary
   INVALID_MEMBER_CHECKLIST_ID(HttpStatus.BAD_REQUEST, "D001","Member Checklist Id가 올바르지 않습니다."),

--- a/src/main/java/com/dnd/bbok/global/security/SecurityConfig.java
+++ b/src/main/java/com/dnd/bbok/global/security/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
 
     http//HTTP 헤더에 사용자의 이름과 암호 포함을 비활성화
         .authorizeRequests()
-        .antMatchers(HttpMethod.GET, "/test", "/api/v1/member", "/api/v1/checklist", "/api/v1/character").authenticated() //해당 요청은 인증이 필요하다.
+        .antMatchers(HttpMethod.GET, "/test", "/api/v1/member", "/api/v1/checklist", "/api/v1/character", "/friend").authenticated() //해당 요청은 인증이 필요하다.
         .antMatchers(HttpMethod.POST, "/friend").authenticated()
         .antMatchers("/**").permitAll() //해당 요청은 누구나 다 들어올 수 있다.
         .and()

--- a/src/main/java/com/dnd/bbok/mock/FriendMockController.java
+++ b/src/main/java/com/dnd/bbok/mock/FriendMockController.java
@@ -2,7 +2,6 @@ package com.dnd.bbok.mock;
 
 import com.dnd.bbok.domain.checklist.dto.request.ChecklistInfoRequestDto;
 import com.dnd.bbok.domain.checklist.dto.response.MyChecklistDto;
-import com.dnd.bbok.domain.friend.dto.response.FriendsDto;
 import com.dnd.bbok.global.response.DataResponse;
 import com.dnd.bbok.global.response.MessageResponse;
 import io.swagger.annotations.Api;
@@ -19,15 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 @Api(tags = "Mock 친구 관련 컨트롤러")
 public class FriendMockController {
-
-  @ApiOperation(value = "친구 목록 조회")
-  @GetMapping("/friend")
-  public ResponseEntity<DataResponse<FriendsDto>> getFriends() {
-    FriendsDto friends = new FriendsDto();
-    return new ResponseEntity<>(
-        DataResponse.of(HttpStatus.OK, "친구 목록 조회 성공", friends), HttpStatus.OK);
-  }
-
 
   @ApiOperation(value = "나만의 기준 조회")
   @GetMapping("/friend/checklist")


### PR DESCRIPTION
## What is this PR? 🔍
- 등록한 친구 목록을 조회하는 기능 및 API 구현
- Close #19

## Key Changes 📝
- [X] 친구 목록을 조회할 때, Diary 정보와 Friend 정보가 필요할 것 같아 이 두개를 엮은 ..
`DiaryFriendUsecaseService` 로 생성

## Test Checklist ✅
- Nothing

## To Reviewers
- 승훈님이 요청하신 friendId로 친구 조회 기능, 친구 점수 update 메서드 구현해놨습니다! 
TODO로 표시해놨으니, 확인 부탁드려요~

- 쿼리 비교 설명
친구 목록을 조회할 때, 다이어리 개수를 알아야 해서 승훈님께서 기존에 작성해두신 `getDiariesByFriendId`를 사용했었는데요.
기능을 구현하고 제대로 데이터는 가져왔지만, 필요없는 정보까지 다 들고오는 부분을 해결하고 싶었습니다.
![image](https://github.com/dnd-side-project/dnd-9th-10-backend/assets/94590894/bbc98692-a943-4bde-9a44-8f3bab1f5461)

그래서, `countDiariesByFriendId`라는 메서드를 따로 정의하였습니다.
![image](https://github.com/dnd-side-project/dnd-9th-10-backend/assets/94590894/a646034e-9756-45fa-afe7-452f0b4a216b)

