### PR TITLE
chore: 친구 관련 패키지 구조 틀 생성

### DIFF
--- a/src/main/java/com/dnd/bbok/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/dnd/bbok/domain/friend/controller/FriendController.java
@@ -1,7 +1,6 @@
 package com.dnd.bbok.domain.friend.controller;
 
 import com.dnd.bbok.domain.friend.dto.request.FriendRequestDto;
-import com.dnd.bbok.domain.friend.dto.response.BbokCharactersDto;
 import com.dnd.bbok.domain.friend.dto.response.FriendsDto;
 import com.dnd.bbok.domain.friend.service.DiaryFriendUseCaseService;
 import com.dnd.bbok.domain.friend.service.MemberFriendUseCaseService;
@@ -32,14 +31,14 @@ public class FriendController {
   private final MemberFriendUseCaseService memberFriendUseCaseService;
   private final DiaryFriendUseCaseService diaryFriendUseCaseService;
 
-  @ApiOperation(value = "캐릭터 정보 제공")
-  @GetMapping("/character")
-  @PreAuthorize("isAuthenticated()")
-  public ResponseEntity<DataResponse<BbokCharactersDto>> getBbokCharacter() {
-    BbokCharactersDto characters = iconService.getCharacterIcon();
-    return new ResponseEntity<>(
-        DataResponse.of(HttpStatus.OK, "캐릭터 목록 제공 성공", characters), HttpStatus.OK);
-  }
+//  @ApiOperation(value = "캐릭터 정보 제공")
+//  @GetMapping("/character")
+//  @PreAuthorize("isAuthenticated()")
+//  public ResponseEntity<DataResponse<BbokCharactersDto>> getBbokCharacter() {
+//    BbokCharactersDto characters = iconService.getCharacterIcon();
+//    return new ResponseEntity<>(
+//        DataResponse.of(HttpStatus.OK, "캐릭터 목록 제공 성공", characters), HttpStatus.OK);
+//  }
 
   @ApiOperation(value = "친구 등록")
   @PostMapping("/friend")

--- a/src/main/java/com/dnd/bbok/friend/adapter/in/web/GetFriendCharacterController.java
+++ b/src/main/java/com/dnd/bbok/friend/adapter/in/web/GetFriendCharacterController.java
@@ -1,0 +1,33 @@
+package com.dnd.bbok.friend.adapter.in.web;
+
+import com.dnd.bbok.domain.friend.dto.response.BbokCharactersDto;
+import com.dnd.bbok.friend.application.port.in.usecase.GetIconQuery;
+import com.dnd.bbok.global.response.DataResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@Api(tags = "친구 관련 컨트롤러")
+@RequiredArgsConstructor
+public class GetFriendCharacterController {
+
+  private final GetIconQuery getIconQuery;
+
+  @ApiOperation(value = "캐릭터 정보 제공")
+  @GetMapping("/character")
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<DataResponse<BbokCharactersDto>> getBbokCharacter() {
+    BbokCharactersDto characters = getIconQuery.getCharacterIcon();
+    return new ResponseEntity<>(
+        DataResponse.of(HttpStatus.OK, "캐릭터 목록 제공 성공", characters), HttpStatus.OK);
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/friend/adapter/in/web/GetFriendCharacterController.java
+++ b/src/main/java/com/dnd/bbok/friend/adapter/in/web/GetFriendCharacterController.java
@@ -1,15 +1,8 @@
 package com.dnd.bbok.friend.adapter.in.web;
 
-import com.dnd.bbok.domain.friend.dto.response.BbokCharactersDto;
 import com.dnd.bbok.friend.application.port.in.usecase.GetIconQuery;
-import com.dnd.bbok.global.response.DataResponse;
 import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,14 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class GetFriendCharacterController {
 
   private final GetIconQuery getIconQuery;
-
-  @ApiOperation(value = "캐릭터 정보 제공")
-  @GetMapping("/character")
-  @PreAuthorize("isAuthenticated()")
-  public ResponseEntity<DataResponse<BbokCharactersDto>> getBbokCharacter() {
-    BbokCharactersDto characters = getIconQuery.getCharacterIcon();
-    return new ResponseEntity<>(
-        DataResponse.of(HttpStatus.OK, "캐릭터 목록 제공 성공", characters), HttpStatus.OK);
-  }
+  //TODO: 컨트롤러 추가하기
 
 }

--- a/src/main/java/com/dnd/bbok/friend/adapter/out/persistence/entity/FriendEntity.java
+++ b/src/main/java/com/dnd/bbok/friend/adapter/out/persistence/entity/FriendEntity.java
@@ -1,0 +1,59 @@
+package com.dnd.bbok.friend.adapter.out.persistence.entity;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+
+import com.dnd.bbok.domain.friend.entity.BbokCharacter;
+import com.dnd.bbok.domain.member.entity.Member;
+import com.sun.istack.NotNull;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class FriendEntity {
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  private BbokCharacter bbok;
+
+  @NotNull
+  private String name;
+
+  private boolean active;
+
+  @NotNull
+  private Long friendScore;
+
+  /**
+   * 친구와 회원을 다대일 관계 매핑
+   */
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  public void changeFriendScore(Long friendScore) {
+    this.friendScore = friendScore;
+  }
+
+  @Builder
+  public FriendEntity(BbokCharacter bbok, String name, boolean active, Long friendScore, Member member) {
+    this.bbok = bbok;
+    this.name = name;
+    this.active = active;
+    this.friendScore = friendScore;
+    this.member = member;
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/friend/adapter/out/persistence/repository/FriendTestRepository.java
+++ b/src/main/java/com/dnd/bbok/friend/adapter/out/persistence/repository/FriendTestRepository.java
@@ -1,0 +1,9 @@
+package com.dnd.bbok.friend.adapter.out.persistence.repository;
+
+import com.dnd.bbok.friend.adapter.out.persistence.entity.FriendEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendTestRepository extends JpaRepository<FriendEntity, UUID> {
+
+}

--- a/src/main/java/com/dnd/bbok/friend/application/port/in/usecase/GetIconQuery.java
+++ b/src/main/java/com/dnd/bbok/friend/application/port/in/usecase/GetIconQuery.java
@@ -1,0 +1,9 @@
+package com.dnd.bbok.friend.application.port.in.usecase;
+
+import com.dnd.bbok.domain.friend.dto.response.BbokCharactersDto;
+
+public interface GetIconQuery {
+
+  BbokCharactersDto getCharacterIcon();
+
+}

--- a/src/main/java/com/dnd/bbok/friend/application/port/out/LoadIconPort.java
+++ b/src/main/java/com/dnd/bbok/friend/application/port/out/LoadIconPort.java
@@ -2,5 +2,4 @@ package com.dnd.bbok.friend.application.port.out;
 
 public interface LoadIconPort {
 
-
 }

--- a/src/main/java/com/dnd/bbok/friend/application/port/out/LoadIconPort.java
+++ b/src/main/java/com/dnd/bbok/friend/application/port/out/LoadIconPort.java
@@ -1,0 +1,6 @@
+package com.dnd.bbok.friend.application.port.out;
+
+public interface LoadIconPort {
+
+
+}

--- a/src/main/java/com/dnd/bbok/friend/application/service/FriendIconService.java
+++ b/src/main/java/com/dnd/bbok/friend/application/service/FriendIconService.java
@@ -1,0 +1,21 @@
+package com.dnd.bbok.friend.application.service;
+
+import com.dnd.bbok.domain.friend.dto.response.BbokCharactersDto;
+import com.dnd.bbok.friend.application.port.in.usecase.GetIconQuery;
+import com.dnd.bbok.friend.application.port.out.LoadIconPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FriendIconService implements GetIconQuery {
+
+  private final LoadIconPort loadIconPort;
+
+  @Override
+  public BbokCharactersDto getCharacterIcon() {
+    return null;
+  }
+}

--- a/src/main/java/com/dnd/bbok/friend/application/service/FriendIconService.java
+++ b/src/main/java/com/dnd/bbok/friend/application/service/FriendIconService.java
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class FriendIconService implements GetIconQuery {
 
-  private final LoadIconPort loadIconPort;
-
   @Override
   public BbokCharactersDto getCharacterIcon() {
     return null;

--- a/src/main/java/com/dnd/bbok/friend/domain/BbokCharacter.java
+++ b/src/main/java/com/dnd/bbok/friend/domain/BbokCharacter.java
@@ -1,0 +1,31 @@
+package com.dnd.bbok.friend.domain;
+
+public enum BbokCharacter {
+  FRONT_CACTUS("CACTUS", "인장이", "front_cactus.png"),
+  FRONT_HEDGEHOG("HEDGEHOG", "고스미", "front_hedgehog.png"),
+  SIDE_CACTUS("CACTUS", "인장이", "side_cactus.png"),
+  SIDE_HEDGEHOG("HEDGEHOG", "고스미", "side_hedgehog.png");
+
+  private final String type;
+  private final String name;
+  private final String iconFile;
+
+  BbokCharacter(String type, String name, String iconFile) {
+    this.type = type;
+    this.name = name;
+    this.iconFile = iconFile;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getIconFile() {
+    return iconFile;
+  }
+
+}

--- a/src/main/java/com/dnd/bbok/friend/domain/Friend.java
+++ b/src/main/java/com/dnd/bbok/friend/domain/Friend.java
@@ -1,0 +1,17 @@
+package com.dnd.bbok.friend.domain;
+
+import com.dnd.bbok.domain.friend.entity.BbokCharacter;
+
+public class Friend {
+
+  private Long id;
+
+  private BbokCharacter bbok;
+
+  private String name;
+
+  private boolean active;
+
+  private Long friendScore;
+
+}


### PR DESCRIPTION
## What is this PR? 🔍
- Hexagonal architecture에 기반하여 친구 관련 패키지 구조 뼈대를 생성했습니다.
- Close #54

## Key Changes 📝
- [X] 도메인과 JPA 엔티티 분리
- [X] 코드 없이 간단한 클래스만 생성 

## Test Checklist ✅
- Nothing

## To Reviewers
이미지 제공까지 구현하고 올리려했는데,, 시간이 너무 늦어서 일단 도메인과 JPA 엔티티 분리까지 하고 올려두겠습니다!