### PR TITLE
[Feature/#72] 일기 목록 페이징 및 검색 / 정렬기능 구현

### DIFF
--- a/src/main/java/com/dnd/bbok/diary/adapter/out/persistence/DiaryAdapter.java
+++ b/src/main/java/com/dnd/bbok/diary/adapter/out/persistence/DiaryAdapter.java
@@ -42,6 +42,8 @@ import static com.dnd.bbok.global.exception.ErrorCode.FRIEND_NOT_FOUND;
 @RequiredArgsConstructor
 @Slf4j
 public class DiaryAdapter implements SaveDiaryPort, LoadDiaryPort {
+    private final int PAGE_SIZE = 20;
+
     private final FriendTagRepository friendTagRepository;
     private final FriendRepository friendRepository;
     private final DiaryRepository diaryRepository;
@@ -121,9 +123,9 @@ public class DiaryAdapter implements SaveDiaryPort, LoadDiaryPort {
 
         Pageable pageable;
         if (Objects.equals(order, "asc")) {
-            pageable = PageRequest.of(offset / 20, 20, Sort.Direction.ASC, "diaryDate");
+            pageable = PageRequest.of(offset / PAGE_SIZE, PAGE_SIZE, Sort.Direction.ASC, "diaryDate");
         } else {
-            pageable = PageRequest.of(offset / 20, 20, Sort.Direction.DESC, "diaryDate");
+            pageable = PageRequest.of(offset / PAGE_SIZE, PAGE_SIZE, Sort.Direction.DESC, "diaryDate");
         }
 
         if (keyword == null) {

--- a/src/main/java/com/dnd/bbok/diary/adapter/out/persistence/entity/DiaryEntity.java
+++ b/src/main/java/com/dnd/bbok/diary/adapter/out/persistence/entity/DiaryEntity.java
@@ -8,6 +8,8 @@ import com.dnd.bbok.diary.domain.Emoji;
 import com.dnd.bbok.friend.adapter.out.persistence.entity.FriendEntity;
 import com.sun.istack.NotNull;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.*;
 
 import lombok.Builder;
@@ -43,8 +45,15 @@ public class DiaryEntity extends BaseTimeEntity {
   @JoinColumn(name = "friend_id")
   private FriendEntity friend;
 
+  @OneToMany(mappedBy = "diaryEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<DiaryTagEntity> diaryTags = new ArrayList<>();
+
+  @OneToMany(mappedBy = "diaryEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<DiaryChecklistEntity> diaryChecklists = new ArrayList<>();
+
   @Builder
-  public DiaryEntity(Emoji emoji, String contents, LocalDate diaryDate, FriendEntity friend, String sticker) {
+  public DiaryEntity(Long id, Emoji emoji, String contents, LocalDate diaryDate, FriendEntity friend, String sticker) {
+    this.id = id;
     this.emoji = emoji;
     this.contents = contents;
     this.diaryDate = diaryDate;

--- a/src/main/java/com/dnd/bbok/diary/adapter/out/persistence/mapper/DiaryMapper.java
+++ b/src/main/java/com/dnd/bbok/diary/adapter/out/persistence/mapper/DiaryMapper.java
@@ -13,14 +13,8 @@ import java.util.stream.Collectors;
 @Component
 public class DiaryMapper {
     public Diary toEntity(DiaryEntity diaryEntity, List<Tag> tags, List<DiaryChecklist> diaryChecklists) {
-        return new Diary(diaryEntity.getId(), diaryEntity.getEmoji(), diaryEntity.getContents(), diaryEntity.getDiaryDate(), diaryEntity.getSticker(), tags, diaryChecklists);
-    }
-
-    public List<Diary> toEntities(List<DiaryEntity> diaryEntities, List<Tag> tags, List<DiaryChecklist> diaryChecklists) {
-        return diaryEntities.stream().map(diaryEntity -> {
-            List<Tag> targetTags = tags.stream().filter(tag -> Objects.equals(tag.getDiaryId(), diaryEntity.getId())).collect(Collectors.toList());
-            List<DiaryChecklist> targetChecklists = diaryChecklists.stream().filter(diaryChecklist -> Objects.equals(diaryChecklist.getDiaryId(), diaryEntity.getId())).collect(Collectors.toList());
-            return new Diary(diaryEntity.getId(), diaryEntity.getEmoji(), diaryEntity.getContents(), diaryEntity.getDiaryDate(), diaryEntity.getSticker(), targetTags, targetChecklists);
-        }).collect(Collectors.toList());
+        List<Tag> targetTags = tags.stream().filter(tag -> Objects.equals(tag.getDiaryId(), diaryEntity.getId())).collect(Collectors.toList());
+        List<DiaryChecklist> targetChecklists = diaryChecklists.stream().filter(diaryChecklist -> Objects.equals(diaryChecklist.getDiaryId(), diaryEntity.getId())).collect(Collectors.toList());
+        return new Diary(diaryEntity.getId(), diaryEntity.getEmoji(), diaryEntity.getContents(), diaryEntity.getDiaryDate(), diaryEntity.getSticker(), targetTags, targetChecklists);
     }
 }

--- a/src/main/java/com/dnd/bbok/diary/adapter/out/persistence/repository/DiaryRepository.java
+++ b/src/main/java/com/dnd/bbok/diary/adapter/out/persistence/repository/DiaryRepository.java
@@ -1,15 +1,29 @@
 package com.dnd.bbok.diary.adapter.out.persistence.repository;
 
 import com.dnd.bbok.diary.adapter.out.persistence.entity.DiaryEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
-    List<DiaryEntity> findAllByFriendId(Long friendId);
-
     @Query("select count(*) from DiaryEntity d where d.friend.id = :friendId")
-    int countDiaries(@Param("friendId") Long friendId);
+    int countDiariesByFriendId(@Param("friendId") Long friendId);
+
+    @Query(value = "SELECT DISTINCT d FROM DiaryEntity d "
+            + "LEFT JOIN d.diaryTags dt "
+            + "LEFT JOIN dt.friendTagEntity ft "
+            + "WHERE d.friend.id = :friendId "
+            + "AND d.contents LIKE %:keyword%"
+            + "AND ft.name LIKE %:tag%",
+    countQuery = "SELECT COUNT(DISTINCT d) FROM DiaryEntity d "
+            + "LEFT JOIN d.diaryTags dt "
+            + "LEFT JOIN dt.friendTagEntity ft "
+            + "WHERE d.friend.id = :friendId "
+            + "AND d.contents LIKE %:keyword%"
+            + "AND ft.name LIKE %:tag%")
+    Page<DiaryEntity> findDiaries(Long friendId, String keyword, String tag, Pageable pageable);
+
 }

--- a/src/main/java/com/dnd/bbok/diary/application/port/in/response/GetDiariesResponse.java
+++ b/src/main/java/com/dnd/bbok/diary/application/port/in/response/GetDiariesResponse.java
@@ -1,8 +1,12 @@
 package com.dnd.bbok.diary.application.port.in.response;
 
+import com.dnd.bbok.diary.domain.Diary;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
+
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class GetDiariesResponse {
@@ -11,29 +15,30 @@ public class GetDiariesResponse {
     private final List<GetDiaryResponse> diaries;
 
     @ApiModelProperty("시작 offset")
-    private final int offset;
+    private final long offset;
 
     @ApiModelProperty("페이지 당 담을 수 있는 최대 용량의 데이터 개수")
     private final int pageNumber;
 
     @ApiModelProperty("현재 페이지 번호 (0부터 시작)")
-    private final int pageSize = 20;
+    private final int pageSize;
 
     @ApiModelProperty("전체 요소 개수 (필터링에 만족하는)")
     private final int totalPages;
 
     @ApiModelProperty("전체 페이지의 개수 (필터링에 만족하는)")
-    private final int totalElements;
+    private final long totalElements;
 
     @ApiModelProperty("현재 페이지에 담긴 데이터 개수")
     private final int numberOfElements;
 
-    public GetDiariesResponse(List<GetDiaryResponse> diaries) {
-        this.diaries = diaries;
-        this.offset = 0;
-        this.pageNumber = 0;
-        this.totalElements = 1;
-        this.totalPages = 1;
-        this.numberOfElements = diaries.size();
+    public GetDiariesResponse(Page<Diary> diaries) {
+        this.diaries = diaries.getContent().stream().map(GetDiaryResponse::new).collect(Collectors.toList());
+        this.numberOfElements = diaries.getNumberOfElements();
+        this.offset = diaries.getPageable().getOffset();
+        this.pageNumber = diaries.getPageable().getPageNumber();
+        this.pageSize = diaries.getPageable().getPageSize();
+        this.totalElements = diaries.getTotalElements();
+        this.totalPages = diaries.getTotalPages();
     }
 }

--- a/src/main/java/com/dnd/bbok/diary/application/port/out/LoadDiaryPort.java
+++ b/src/main/java/com/dnd/bbok/diary/application/port/out/LoadDiaryPort.java
@@ -1,11 +1,10 @@
 package com.dnd.bbok.diary.application.port.out;
 
 import com.dnd.bbok.diary.domain.Diary;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 public interface LoadDiaryPort {
     Diary loadDiary(Long diaryId);
-    List<Diary> loadDiaries(Long friendId);
+    Page<Diary> loadDiaries(Long friendId, Integer offset, String order, String keyword, String tag);
     int countDiariesByFriendId(Long friendId);
 }

--- a/src/main/java/com/dnd/bbok/diary/application/service/GetDiaryService.java
+++ b/src/main/java/com/dnd/bbok/diary/application/service/GetDiaryService.java
@@ -8,9 +8,6 @@ import com.dnd.bbok.diary.application.port.out.LoadDiaryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Service
 @RequiredArgsConstructor
 public class GetDiaryService implements GetDiariesQuery, GetDiaryQuery {
@@ -18,8 +15,7 @@ public class GetDiaryService implements GetDiariesQuery, GetDiaryQuery {
 
     @Override
     public GetDiariesResponse getDiariesQuery(Long friendId, Integer offset, String order, String keyword, String tag) {
-        List<GetDiaryResponse> getDiaryResponses = loadDiaryPort.loadDiaries(friendId).stream().map(GetDiaryResponse::new).collect(Collectors.toList());
-        return new GetDiariesResponse(getDiaryResponses);
+        return new GetDiariesResponse(loadDiaryPort.loadDiaries(friendId, offset,order, keyword, tag));
     }
 
     @Override


### PR DESCRIPTION
## What is this PR? 🔍
- 일기 목록 조회의 페이징 기능울 구현하였습니다.
- Close #72 

## Key Changes 📝
- [x] Diary Entity에 OneToMany 매핑을 추가하였습니다.

## Test Checklist ✅
- [x] Swagger Test (일기 30개 생성, offset 바꿔가며 테스트, 검색어 + 태그 + offest 동시 테스트 등)

## To Reviewers